### PR TITLE
Correct name of package in warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 try:
     import robofab
 except:
-    print "*** Warning: defcon requires RoboFab, see:"
+    print "*** Warning: fontMath requires RoboFab, see:"
     print "    robofab.com"
 
 


### PR DESCRIPTION
This one is for the `ufo3` branch.