### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
-*.pyc
+# Byte-compiled and optimized files
+__pycache__/
+*.py[co]
+*$py.class
+
+# Packaging
+*.egg-info
+MANIFEST
+
+# Unit test and coverage files
+.cache
+.coverage
+.coverage.*
+.tox
+
+# OS X Finder
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,37 @@
+sudo: false
 language: python
-sudo: required
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
-  - "3.5"
-before_install:
-  - git clone https://github.com/typesupply/defcon.git --branch ufo3
-  - git clone https://github.com/robofab-developers/robofab.git --branch ufo3k
-  - git clone https://github.com/behdad/fonttools.git
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: pypy
+      env: TOXENV=pypy
+    - language: generic
+      os: osx
+      # the default 'osx' on Travis is 10.9 Mavericks, with Python 2.7.5
+      env: TOXENV=py27
+    - language: generic
+      os: osx
+      # this is to test on 10.11 El Capitan which comes with Python 2.7.10
+      osx_image: xcode7.3
+      env: TOXENV=py27
+    - language: generic
+      os: osx
+      env: TOXENV=py34
+    - language: generic
+      os: osx
+      env: TOXENV=py35
+    - language: generic
+      os: osx
+      env: TOXENV=pypy
+    # coveralls is not listed in tox's envlist, but should run in travis
+    - python: 3.5
+      env: TOXENV=coveralls
 install:
-  - cd defcon; python setup.py install; cd ..
-  - cd robofab; python setup.py install; cd ..
-  - cd fonttools; python setup.py install; cd ..
-  # fontMath
-  - python setup.py install
-  - pip install coveralls
+  - ./.travis/install.sh
 script:
-  - cd Lib/fontMath
-  - coverage run --parallel-mode mathFunctions.py
-  - coverage run --parallel-mode --source=mathGlyph.py mathGlyph.py
-  - coverage run --parallel-mode mathGuideline.py
-  - coverage run --parallel-mode --source=mathInfo.py mathInfo.py
-  - coverage run --parallel-mode --source=mathKerning.py mathKerning.py
-  - coverage run --source=mathTransform.py mathTransform.py
-after_success:
-  - coverage combine
-  - coveralls
+  - ./.travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
+  - "3.5"
 before_install:
   - git clone https://github.com/typesupply/defcon.git --branch ufo3
   - git clone https://github.com/robofab-developers/robofab.git --branch ufo3k

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    # install pyenv from the git repo (quicker than using brew)
+    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    case "${TOXENV}" in
+        py27)
+            # install pip on the system python
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py34)
+            pyenv install 3.4.3
+            pyenv global 3.4.3
+            ;;
+        py35)
+            pyenv install 3.5.1
+            pyenv global 3.5.1
+            ;;
+        pypy)
+            pyenv install pypy-5.0.0
+            pyenv global pypy-5.0.0
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install --user --upgrade pip virtualenv
+else
+    # on Linux, we only need pyenv to get the latest pypy
+    if [[ "${TOXENV}" == "pypy" ]]; then
+        git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+        PYENV_ROOT="$HOME/.pyenv"
+        PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+
+        if [[ "${TOXENV}" == "pypy" ]]; then
+            pyenv install pypy-5.0.0
+            pyenv global pypy-5.0.0
+        fi
+        pyenv rehash
+    fi
+    pip install --upgrade pip virtualenv
+fi
+
+# activate virtualenv and install test requirements
+python -m virtualenv ~/.venv
+source ~/.venv/bin/activate
+pip install -r dev-requirements.txt

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == "Darwin" || "${TOXENV}" == "pypy" ]]; then
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+fi
+
+source ~/.venv/bin/activate
+tox

--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -22,51 +22,22 @@ def addPt(pt1, pt2):
     return pt1[0] + pt2[0], pt1[1] + pt2[1]
 
 def sub(v1, v2):
-    """
-    >>> sub(10, 10)
-    0
-    >>> sub(10, -10)
-    20
-    >>> sub(-10, 10)
-    -20
-    """
     return v1 - v2
 
 def subPt(pt1, pt2):
-    """
-    >>> pt1, pt2 = (20, 230), (50, 40)
-    >>> subPt(pt1, pt2)
-    (-30, 190)
-    """
     return pt1[0] - pt2[0], pt1[1] - pt2[1]
 
 def mul(v, f):
     return v * f
 
 def mulPt(pt1, f):
-    """
-    >>> pt1, f1, f2 = (15, 25), 2, 3
-    >>> mulPt(pt1, (f1, f2))
-    (30, 75)
-    """
     (f1, f2) = f
     return pt1[0] * f1, pt1[1] * f2
 
 def div(v, f):
-    """
-    >>> div(4, 2) == 2
-    True
-    >>> div(4, 3) == 1.3333333333333333
-    True
-    """
     return v / f
 
 def divPt(pt, f):
-    """
-    >>> pt1, f1, f2 = (15, 75), 2, 3
-    >>> divPt(pt1, (f1, f2))
-    (7.5, 25.0)
-    """
     (f1, f2) = f
     return pt[0] / f1, pt[1] / f2
 
@@ -82,35 +53,6 @@ def factorAngle(angle, f, func):
     )
 
 def _roundNumber(n, digits=None):
-    """
-    round to integer:
-    >>> _roundNumber(0)
-    0
-    >>> _roundNumber(0.1)
-    0
-    >>> _roundNumber(0.99)
-    1
-    >>> _roundNumber(0.499)
-    0
-    >>> _roundNumber(0.5)
-    1
-    >>> _roundNumber(-0.499)
-    0
-    >>> _roundNumber(-0.5)
-    -1
-
-    round to float with specified decimals:
-    >>> _roundNumber(0.3333, None) == 0
-    True
-    >>> _roundNumber(0.3333, 0) == 0.0
-    True
-    >>> _roundNumber(0.3333, 1) == 0.3
-    True
-    >>> _roundNumber(0.3333, 2) == 0.33
-    True
-    >>> _roundNumber(0.3333, 3) == 0.333
-    True
-    """
     # Python3 rounds halves to nearest even integer but Python2 rounds
     # halves up in positives and down in negatives
     if round(0.5) != 1 and n % 1 == .5 and not int(n) % 2:

--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -346,64 +346,6 @@ class MathGlyphPen(AbstractPointPen):
 
     """
     Point pen for building MathGlyph data structures.
-
-    >>> pen = MathGlyphPen()
-    >>> pen.beginPath(identifier="contour 1")
-    >>> pen.addPoint((  0, 100), "line", smooth=False, name="name 1", identifier="point 1")
-    >>> pen.addPoint((100, 100), "line", smooth=False, name="name 2", identifier="point 2")
-    >>> pen.addPoint((100,   0), "line", smooth=False, name="name 3", identifier="point 3")
-    >>> pen.addPoint((  0,   0), "line", smooth=False, name="name 4", identifier="point 4")
-    >>> pen.endPath()
-    >>> expected = [
-    ...     ("curve", (  0, 100), False, "name 1", "point 1"),
-    ...     (None,    (  0, 100), False, None,     None),
-    ...     (None,    (100, 100), False, None,     None),
-    ...     ("curve", (100, 100), False, "name 2", "point 2"),
-    ...     (None,    (100, 100), False, None,     None),
-    ...     (None,    (100,   0), False, None,     None),
-    ...     ("curve", (100,   0), False, "name 3", "point 3"),
-    ...     (None,    (100,   0), False, None,     None),
-    ...     (None,    (  0,   0), False, None,     None),
-    ...     ("curve", (  0,   0), False, "name 4", "point 4"),
-    ...     (None,    (  0,   0), False, None,     None),
-    ...     (None,    (  0, 100), False, None,     None),
-    ... ]
-    >>> pen.contours[-1]["points"] == expected
-    True
-    >>> pen.contours[-1]["identifier"]
-    'contour 1'
-
-    >>> pen = MathGlyphPen()
-    >>> pen.beginPath(identifier="contour 1")
-    >>> pen.addPoint((  0,  50), "curve", smooth=False, name="name 1", identifier="point 1")
-    >>> pen.addPoint(( 50, 100), "line", smooth=False, name="name 2", identifier="point 2")
-    >>> pen.addPoint(( 75, 100), None)
-    >>> pen.addPoint((100,  75), None)
-    >>> pen.addPoint((100,  50), "curve", smooth=True, name="name 3", identifier="point 3")
-    >>> pen.addPoint((100,  25), None)
-    >>> pen.addPoint(( 75,   0), None)
-    >>> pen.addPoint(( 50,   0), "curve", smooth=False, name="name 4", identifier="point 4")
-    >>> pen.addPoint(( 25,   0), None)
-    >>> pen.addPoint((  0,  25), None)
-    >>> pen.endPath()
-    >>> expected = [
-    ...     ("curve", (  0,  50), False, "name 1", "point 1"),
-    ...     (None,    (  0,  50), False, None,     None),
-    ...     (None,    ( 50, 100), False, None,     None),
-    ...     ("curve", ( 50, 100), False, "name 2", "point 2"),
-    ...     (None,    ( 75, 100), False, None,     None),
-    ...     (None,    (100,  75), False, None,     None),
-    ...     ("curve", (100,  50), True, "name 3", "point 3"),
-    ...     (None,    (100,  25), False, None,     None),
-    ...     (None,    ( 75,   0), False, None,     None),
-    ...     ("curve", ( 50,   0), False, "name 4", "point 4"),
-    ...     (None,    ( 25,   0), False, None,     None),
-    ...     (None,    (  0,  25), False, None,     None),
-    ... ]
-    >>> pen.contours[-1]["points"] == expected
-    True
-    >>> pen.contours[-1]["identifier"]
-    'contour 1'
     """
 
     def __init__(self, glyph=None):
@@ -481,35 +423,6 @@ class FilterRedundantPointPen(AbstractPointPen):
         self._points = []
 
     def _flushContour(self):
-        """
-        >>> points = [
-        ...     ("curve", (  0, 100), False, "name 1", "point 1"),
-        ...     (None,    (  0, 100), False, None,     None),
-        ...     (None,    (100, 100), False, None,     None),
-        ...     ("curve", (100, 100), False, "name 2", "point 2"),
-        ...     (None,    (100, 100), False, None,     None),
-        ...     (None,    (100,   0), False, None,     None),
-        ...     ("curve", (100,   0), False, "name 3", "point 3"),
-        ...     (None,    (100,   0), False, None,     None),
-        ...     (None,    (  0,   0), False, None,     None),
-        ...     ("curve", (  0,   0), False, "name 4", "point 4"),
-        ...     (None,    (  0,   0), False, None,     None),
-        ...     (None,    (  0, 100), False, None,     None),
-        ... ]
-        >>> testPen = _TestPointPen()
-        >>> filterPen = FilterRedundantPointPen(testPen)
-        >>> filterPen.beginPath(identifier="contour 1")
-        >>> for segmentType, pt, smooth, name, identifier in points:
-        ...     filterPen.addPoint(pt, segmentType=segmentType, smooth=smooth, name=name, identifier=identifier)
-        >>> filterPen.endPath()
-        >>> testPen.dump()
-        beginPath(identifier="contour 1")
-        addPoint((0, 100), segmentType="line", smooth=False, name="name 1", identifier="point 1")
-        addPoint((100, 100), segmentType="line", smooth=False, name="name 2", identifier="point 2")
-        addPoint((100, 0), segmentType="line", smooth=False, name="name 3", identifier="point 3")
-        addPoint((0, 0), segmentType="line", smooth=False, name="name 4", identifier="point 4")
-        endPath()
-        """
         points = self._points
         prevOnCurve = None
         offCurves = []
@@ -586,46 +499,6 @@ class FilterRedundantPointPen(AbstractPointPen):
     def addComponent(self, baseGlyph, transformation, identifier=None, **kwargs):
         self._pen.addComponent(baseGlyph, transformation, identifier)
 
-
-class _TestPointPen(AbstractPointPen):
-
-    def __init__(self):
-        self._text = []
-
-    def dump(self):
-        for line in self._text:
-            print(line)
-
-    def _prep(self, i):
-        if isinstance(i, basestring):
-            i = "\"%s\"" % i
-        return str(i)
-
-    def beginPath(self, identifier=None, **kwargs):
-        self._text.append("beginPath(identifier=%s)" % self._prep(identifier))
-
-    def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
-        self._text.append("addPoint(%s, segmentType=%s, smooth=%s, name=%s, identifier=%s)" % (
-                self._prep(pt),
-                self._prep(segmentType),
-                self._prep(smooth),
-                self._prep(name),
-                self._prep(identifier)
-            )
-        )
-
-    def endPath(self):
-        self._text.append("endPath()")
-
-    def addComponent(self, baseGlyph, transformation, identifier=None, **kwargs):
-        self._text.append("addComponent(baseGlyph=%s, transformation=%s, identifier=%s)" % (
-                self._prep(baseGlyph),
-                self._prep(transformation),
-                self._prep(identifier)
-            )
-        )
-
-
 # -------
 # Support
 # -------
@@ -633,19 +506,6 @@ class _TestPointPen(AbstractPointPen):
 # contours
 
 def _processMathOneContours(contours1, contours2, func):
-    """
-    >>> contours1 = [
-    ...     dict(identifier="contour 1", points=[("line", (1, 3), False, "test", "1")])
-    ... ]
-    >>> contours2 = [
-    ...     dict(identifier=None, points=[(None, (4, 6), True, None, None)])
-    ... ]
-    >>> expected = [
-    ...     dict(identifier="contour 1", points=[("line", (5, 9), False, "test", "1")])
-    ... ]
-    >>> _processMathOneContours(contours1, contours2, addPt) == expected
-    True
-    """
     result = []
     for index, contour1 in enumerate(contours1):
         contourIdentifier = contour1["identifier"]
@@ -661,16 +521,6 @@ def _processMathOneContours(contours1, contours2, func):
     return result
 
 def _processMathTwoContours(contours, factor, func):
-    """
-    >>> contours = [
-    ...     dict(identifier="contour 1", points=[("line", (1, 3), False, "test", "1")])
-    ... ]
-    >>> expected = [
-    ...     dict(identifier="contour 1", points=[("line", (2, 4.5), False, "test", "1")])
-    ... ]
-    >>> _processMathTwoContours(contours, (2, 1.5), mulPt) == expected
-    True
-    """
     result = []
     for contour in contours:
         contourIdentifier = contour["identifier"]
@@ -686,28 +536,6 @@ def _processMathTwoContours(contours, factor, func):
 # anchors
 
 def _anchorTree(anchors):
-    """
-    >>> anchors = [
-    ...     dict(identifier="1", name="test", x=1, y=2, color=None),
-    ...     dict(name="test", x=1, y=2, color=None),
-    ...     dict(name="test", x=3, y=4, color=None),
-    ...     dict(name="test", x=2, y=3, color=None),
-    ...     dict(name="test 2", x=1, y=2, color=None),
-    ... ]
-    >>> expected = {
-    ...     "test" : [
-    ...         ("1", 1, 2, None),
-    ...         (None, 1, 2, None),
-    ...         (None, 3, 4, None),
-    ...         (None, 2, 3, None),
-    ...     ],
-    ...     "test 2" : [
-    ...         (None, 1, 2, None)
-    ...     ]
-    ... }
-    >>> _anchorTree(anchors) == expected
-    True
-    """
     tree = {}
     for anchor in anchors:
         x = anchor["x"]
@@ -816,19 +644,6 @@ def _pairAnchors(anchorDict1, anchorDict2):
     return pairs
 
 def _processMathOneAnchors(anchorPairs, func):
-    """
-    >>> anchorPairs = [
-    ...     (
-    ...         dict(x=100, y=-100, name="foo", identifier="1", color="0,0,0,0"),
-    ...         dict(x=200, y=-200, name="bar", identifier="2", color="1,1,1,1")
-    ...     )
-    ... ]
-    >>> expected = [
-    ...     dict(x=300, y=-300, name="foo", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> _processMathOneAnchors(anchorPairs, addPt) == expected
-    True
-    """
     result = []
     for anchor1, anchor2 in anchorPairs:
         anchor = dict(anchor1)
@@ -839,16 +654,6 @@ def _processMathOneAnchors(anchorPairs, func):
     return result
 
 def _processMathTwoAnchors(anchors, factor, func):
-    """
-    >>> anchors = [
-    ...     dict(x=100, y=-100, name="foo", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> expected = [
-    ...     dict(x=200, y=-150, name="foo", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> _processMathTwoAnchors(anchors, (2, 1.5), mulPt) == expected
-    True
-    """
     result = []
     for anchor in anchors:
         anchor = dict(anchor)
@@ -860,55 +665,6 @@ def _processMathTwoAnchors(anchors, factor, func):
 # components
 
 def _pairComponents(components1, components2):
-    """
-    >>> components1 = [
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier="1"),
-    ...     dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier="1"),
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ... ]
-    >>> components2 = [
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...     dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier="1"),
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier="1")
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier="1"),
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier="1")
-    ...     ),
-    ...     (
-    ...         dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier="1"),
-    ...         dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier="1")
-    ...     ),
-    ...     (
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ...     ),
-    ... ]
-    >>> _pairComponents(components1, components2) == expected
-    True
-
-    >>> components1 = [
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...     dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ... ]
-    >>> components2 = [
-    ...     dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...     dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...         dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ...     ),
-    ...     (
-    ...         dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier=None),
-    ...         dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0), identifier=None)
-    ...     ),
-    ... ]
-    >>> _pairComponents(components1, components2) == expected
-    True
-    """
     components1 = list(components1)
     components2 = list(components2)
     pairs = []
@@ -940,19 +696,6 @@ def _pairComponents(components1, components2):
     return pairs
 
 def _processMathOneComponents(componentPairs, func):
-    """
-    >>> components = [
-    ...    (
-    ...        dict(baseGlyph="A", transformation=( 1,  3,  5,  7,  9, 11), identifier="1"),
-    ...        dict(baseGlyph="A", transformation=(12, 14, 16, 18, 20, 22), identifier=None)
-    ...    )
-    ... ]
-    >>> expected = [
-    ...     dict(baseGlyph="A", transformation=(13, 17, 21, 25, 29, 33), identifier="1")
-    ... ]
-    >>> _processMathOneComponents(components, addPt) == expected
-    True
-    """
     result = []
     for component1, component2 in componentPairs:
         component = dict(component1)
@@ -961,16 +704,6 @@ def _processMathOneComponents(componentPairs, func):
     return result
 
 def _processMathTwoComponents(components, factor, func):
-    """
-    >>> components = [
-    ...     dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5, 6), identifier="1"),
-    ... ]
-    >>> expected = [
-    ...     dict(baseGlyph="A", transformation=(2, 4, 4.5, 6, 10, 9), identifier="1")
-    ... ]
-    >>> _processMathTwoComponents(components, (2, 1.5), mulPt) == expected
-    True
-    """
     result = []
     for component in components:
         component = dict(component)
@@ -987,12 +720,6 @@ for key, value in zip(_imageTransformationKeys, _defaultImageTransformation):
     _defaultImageTransformationDict[key] = value
 
 def _expandImage(image):
-    """
-    >>> _expandImage(None) == dict(fileName=None, transformation=(1, 0, 0, 1, 0, 0), color=None)
-    True
-    >>> _expandImage(dict(fileName="foo")) == dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0), color=None)
-    True
-    """
     if image is None:
         fileName = None
         transformation = _defaultImageTransformation
@@ -1007,11 +734,6 @@ def _expandImage(image):
     return dict(fileName=fileName, transformation=transformation, color=color)
 
 def _compressImage(image):
-    """
-    >>> expected = dict(fileName="foo", color=None, xScale=1, xyScale=0, yxScale=0, yScale=1, xOffset=0, yOffset=0)
-    >>> _compressImage(dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0), color=None)) == expected
-    True
-    """
     fileName = image["fileName"]
     transformation = image["transformation"]
     color = image["color"]
@@ -1023,29 +745,11 @@ def _compressImage(image):
     return image
 
 def _pairImages(image1, image2):
-    """
-    >>> image1 = dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0), color=None)
-    >>> image2 = dict(fileName="foo", transformation=(2, 0, 0, 2, 0, 0), color="0,0,0,0")
-    >>> _pairImages(image1, image2) == (image1, image2)
-    True
-
-    >>> image1 = dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0), color=None)
-    >>> image2 = dict(fileName="bar", transformation=(1, 0, 0, 1, 0, 0), color=None)
-    >>> _pairImages(image1, image2) == ()
-    True
-    """
     if image1["fileName"] != image2["fileName"]:
         return ()
     return (image1, image2)
 
 def _processMathOneImage(imagePair, func):
-    """
-    >>> image1 = dict(fileName="foo", transformation=( 1,  3,  5,  7,  9, 11), color="0,0,0,0")
-    >>> image2 = dict(fileName="bar", transformation=(12, 14, 16, 18, 20, 22), color=None)
-    >>> expected = dict(fileName="foo", transformation=(13, 17, 21, 25, 29, 33), color="0,0,0,0")
-    >>> _processMathOneImage((image1, image2), addPt) == expected
-    True
-    """
     image1, image2 = imagePair
     fileName = image1["fileName"]
     color = image1["color"]
@@ -1053,12 +757,6 @@ def _processMathOneImage(imagePair, func):
     return dict(fileName=fileName, transformation=transformation, color=color)
 
 def _processMathTwoImage(image, factor, func):
-    """
-    >>> image = dict(fileName="foo", transformation=(1, 2, 3, 4, 5, 6), color="0,0,0,0")
-    >>> expected = dict(fileName="foo", transformation=(2, 4, 4.5, 6, 10, 9), color="0,0,0,0")
-    >>> _processMathTwoImage(image, (2, 1.5), mulPt) == expected
-    True
-    """
     fileName = image["fileName"]
     color = image["color"]
     transformation = _processMathTwoTransformation(image["transformation"], factor, func)
@@ -1068,13 +766,6 @@ def _processMathTwoImage(image, factor, func):
 # transformations
 
 def _processMathOneTransformation(transformation1, transformation2, func):
-    """
-    >>> transformation1 = ( 1,  3,  5,  7,  9, 11)
-    >>> transformation2 = (12, 14, 16, 18, 20, 22)
-    >>> expected = (13, 17, 21, 25, 29, 33)
-    >>> _processMathOneTransformation(transformation1, transformation2, addPt) == expected
-    True
-    """
     xScale1, xyScale1, yxScale1, yScale1, xOffset1, yOffset1 = transformation1
     xScale2, xyScale2, yxScale2, yScale2, xOffset2, yOffset2 = transformation2
     xScale, yScale = func((xScale1, yScale1), (xScale2, yScale2))
@@ -1083,12 +774,6 @@ def _processMathOneTransformation(transformation1, transformation2, func):
     return (xScale, xyScale, yxScale, yScale, xOffset, yOffset)
 
 def _processMathTwoTransformation(transformation, factor, func):
-    """
-    >>> transformation = (1, 2, 3, 4, 5, 6)
-    >>> expected = (2, 4, 4.5, 6, 10, 9)
-    >>> _processMathTwoTransformation(transformation, (2, 1.5), mulPt) == expected
-    True
-    """
     xScale, xyScale, yxScale, yScale, xOffset, yOffset = transformation
     xScale, yScale = func((xScale, yScale), factor)
     xyScale, yxScale = func((xyScale, yxScale), factor)
@@ -1099,18 +784,6 @@ def _processMathTwoTransformation(transformation, factor, func):
 # rounding
 
 def _roundContours(contours, digits=None):
-    """
-    >>> contour = [
-    ...     dict(identifier="contour 1", points=[("line", (0.55, 3.1), False, "test", "1")]),
-    ...     dict(identifier="contour 1", points=[("line", (0.55, 3.1), True, "test", "1")])
-    ... ]
-    >>> expected = [
-    ...     dict(identifier="contour 1", points=[("line", (1, 3), False, "test", "1")]),
-    ...     dict(identifier="contour 1", points=[("line", (1, 3), True, "test", "1")])
-    ... ]
-    >>> _roundContours(contour) == expected
-    True
-    """
     results = []
     for contour in contours:
         contour = dict(contour)
@@ -1123,22 +796,10 @@ def _roundContours(contours, digits=None):
     return results
 
 def _roundTransformation(transformation, digits=None):
-    """
-    >>> transformation = (1, 2, 3, 4, 4.99, 6.01)
-    >>> expected = (1, 2, 3, 4, 5, 6)
-    >>> _roundTransformation(transformation) == expected
-    True
-    """
     xScale, xyScale, yxScale, yScale, xOffset, yOffset = transformation
     return (xScale, xyScale, yxScale, yScale, _roundNumber(xOffset, digits), _roundNumber(yOffset, digits))
 
 def _roundImage(image, digits=None):
-    """
-    >>> image = dict(fileName="foo", transformation=(1, 2, 3, 4, 4.99, 6.01), color="0,0,0,0")
-    >>> expected = dict(fileName="foo", transformation=(1, 2, 3, 4, 5, 6), color="0,0,0,0")
-    >>> _roundImage(image) == expected
-    True
-    """
     image = dict(image)
     fileName = image["fileName"]
     color = image["color"]
@@ -1146,16 +807,6 @@ def _roundImage(image, digits=None):
     return dict(fileName=fileName, transformation=transformation, color=color)
 
 def _roundComponents(components, digits=None):
-    """
-    >>> components = [
-    ...     dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5.1, 5.99), identifier="1"),
-    ... ]
-    >>> expected = [
-    ...     dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5, 6), identifier="1")
-    ... ]
-    >>> _roundComponents(components) == expected
-    True
-    """
     result = []
     for component in components:
         component = dict(component)
@@ -1164,16 +815,6 @@ def _roundComponents(components, digits=None):
     return result
 
 def _roundAnchors(anchors, digits=None):
-    """
-    >>> anchors = [
-    ...     dict(x=99.9, y=-100.1, name="foo", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> expected = [
-    ...     dict(x=100, y=-100, name="foo", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> _roundAnchors(anchors) == expected
-    True
-    """
     result = []
     for anchor in anchors:
         anchor = dict(anchor)
@@ -1181,132 +822,6 @@ def _roundAnchors(anchors, digits=None):
         result.append(anchor)
     return result
 
-
-# -----
-# Tests
-# -----
-
-# these are tests that don't fit elsewhere
-
-def _setupTestGlyph():
-    glyph = MathGlyph(None)
-    glyph.width = 0
-    glyph.height = 0
-    return glyph
-
-def _testWidth():
-    """
-    add
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 1
-    >>> glyph2 = _setupTestGlyph()
-    >>> glyph2.width = 2
-    >>> glyph3 = glyph1 + glyph2
-    >>> glyph3.width
-    3
-
-    sub
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 3
-    >>> glyph2 = _setupTestGlyph()
-    >>> glyph2.width = 2
-    >>> glyph3 = glyph1 - glyph2
-    >>> glyph3.width
-    1
-
-    mul
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 2
-    >>> glyph2 = glyph1 * 3
-    >>> glyph2.width
-    6
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 2
-    >>> glyph2 = glyph1 * (3, 1)
-    >>> glyph2.width
-    6
-
-    div
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 7
-    >>> glyph2 = glyph1 / 2
-    >>> glyph2.width
-    3.5
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 7
-    >>> glyph2 = glyph1 / (2, 1)
-    >>> glyph2.width
-    3.5
-
-    round
-    -----
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.width = 6.99
-    >>> glyph2 = glyph1.round()
-    >>> glyph2.width
-    7
-    """
-
-def _testHeight():
-    """
-    add
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 1
-    >>> glyph2 = _setupTestGlyph()
-    >>> glyph2.height = 2
-    >>> glyph3 = glyph1 + glyph2
-    >>> glyph3.height
-    3
-
-    sub
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 3
-    >>> glyph2 = _setupTestGlyph()
-    >>> glyph2.height = 2
-    >>> glyph3 = glyph1 - glyph2
-    >>> glyph3.height
-    1
-
-    mul
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 2
-    >>> glyph2 = glyph1 * 3
-    >>> glyph2.height
-    6
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 2
-    >>> glyph2 = glyph1 * (1, 3)
-    >>> glyph2.height
-    6
-
-    div
-    ---
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 7
-    >>> glyph2 = glyph1 / 2
-    >>> glyph2.height
-    3.5
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 7
-    >>> glyph2 = glyph1 / (1, 2)
-    >>> glyph2.height
-    3.5
-
-    round
-    -----
-    >>> glyph1 = _setupTestGlyph()
-    >>> glyph1.height = 6.99
-    >>> glyph2 = glyph1.round()
-    >>> glyph2.height
-    7
-    """
 
 if __name__ == "__main__":
     import sys

--- a/Lib/fontMath/mathGuideline.py
+++ b/Lib/fontMath/mathGuideline.py
@@ -10,15 +10,6 @@ __all__ = [
 ]
 
 def _expandGuideline(guideline):
-    """
-    >>> guideline = dict(x=100, y=None, angle=None)
-    >>> sorted(_expandGuideline(guideline).items())
-    [('angle', 90), ('x', 100), ('y', 0)]
-
-    >>> guideline = dict(y=100, x=None, angle=None)
-    >>> sorted(_expandGuideline(guideline).items())
-    [('angle', 0), ('x', 0), ('y', 100)]
-    """
     guideline = dict(guideline)
     x = guideline.get("x")
     y = guideline.get("y")
@@ -33,23 +24,6 @@ def _expandGuideline(guideline):
     return guideline
 
 def _compressGuideline(guideline):
-    """
-    >>> guideline = dict(x=100, y=0, angle=90)
-    >>> sorted(_compressGuideline(guideline).items())
-    [('angle', None), ('x', 100), ('y', None)]
-
-    >>> guideline = dict(x=100, y=0, angle=270)
-    >>> sorted(_compressGuideline(guideline).items())
-    [('angle', None), ('x', 100), ('y', None)]
-
-    >>> guideline = dict(y=100, x=0, angle=0)
-    >>> sorted(_compressGuideline(guideline).items())
-    [('angle', None), ('x', None), ('y', 100)]
-
-    >>> guideline = dict(y=100, x=0, angle=180)
-    >>> sorted(_compressGuideline(guideline).items())
-    [('angle', None), ('x', None), ('y', 100)]
-    """
     guideline = dict(guideline)
     x = guideline["x"]
     y = guideline["y"]
@@ -65,139 +39,6 @@ def _compressGuideline(guideline):
     return guideline
 
 def _pairGuidelines(guidelines1, guidelines2):
-    """
-    name + identifier + (x, y, angle)
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="foo", identifier="2", x=3, y=4, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="foo", identifier="2", x=3, y=4, angle=2),
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1)
-    ...     ),
-    ...     (
-    ...         dict(name="foo", identifier="2", x=3, y=4, angle=2),
-    ...         dict(name="foo", identifier="2", x=3, y=4, angle=2)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-
-    name + identifier
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="foo", identifier="2", x=1, y=2, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="foo", identifier="2", x=3, y=4, angle=3),
-    ...     dict(name="foo", identifier="1", x=3, y=4, angle=4)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="foo", identifier="1", x=3, y=4, angle=4)
-    ...     ),
-    ...     (
-    ...         dict(name="foo", identifier="2", x=1, y=2, angle=2),
-    ...         dict(name="foo", identifier="2", x=3, y=4, angle=3)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-
-    name + (x, y, angle)
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="foo", identifier="2", x=3, y=4, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="foo", identifier="3", x=3, y=4, angle=2),
-    ...     dict(name="foo", identifier="4", x=1, y=2, angle=1)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="foo", identifier="4", x=1, y=2, angle=1)
-    ...     ),
-    ...     (
-    ...         dict(name="foo", identifier="2", x=3, y=4, angle=2),
-    ...         dict(name="foo", identifier="3", x=3, y=4, angle=2)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-
-    identifier + (x, y, angle)
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="bar", identifier="2", x=3, y=4, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="xxx", identifier="2", x=3, y=4, angle=2),
-    ...     dict(name="yyy", identifier="1", x=1, y=2, angle=1)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="yyy", identifier="1", x=1, y=2, angle=1)
-    ...     ),
-    ...     (
-    ...         dict(name="bar", identifier="2", x=3, y=4, angle=2),
-    ...         dict(name="xxx", identifier="2", x=3, y=4, angle=2)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-
-    name
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="bar", identifier="2", x=1, y=2, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="bar", identifier="3", x=3, y=4, angle=3),
-    ...     dict(name="foo", identifier="4", x=3, y=4, angle=4)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="foo", identifier="4", x=3, y=4, angle=4)
-    ...     ),
-    ...     (
-    ...         dict(name="bar", identifier="2", x=1, y=2, angle=2),
-    ...         dict(name="bar", identifier="3", x=3, y=4, angle=3)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-
-    identifier
-    >>> guidelines1 = [
-    ...     dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...     dict(name="bar", identifier="2", x=1, y=2, angle=2),
-    ... ]
-    >>> guidelines2 = [
-    ...     dict(name="xxx", identifier="2", x=3, y=4, angle=3),
-    ...     dict(name="yyy", identifier="1", x=3, y=4, angle=4)
-    ... ]
-    >>> expected = [
-    ...     (
-    ...         dict(name="foo", identifier="1", x=1, y=2, angle=1),
-    ...         dict(name="yyy", identifier="1", x=3, y=4, angle=4)
-    ...     ),
-    ...     (
-    ...         dict(name="bar", identifier="2", x=1, y=2, angle=2),
-    ...         dict(name="xxx", identifier="2", x=3, y=4, angle=3)
-    ...     )
-    ... ]
-    >>> _pairGuidelines(guidelines1, guidelines2) == expected
-    True
-    """
     guidelines1 = list(guidelines1)
     guidelines2 = list(guidelines2)
     pairs = []
@@ -234,20 +75,6 @@ def _findPair(guidelines1, guidelines2, pairs, attrs):
             pairs.append((guideline1, guideline2))
 
 def _processMathOneGuidelines(guidelinePairs, ptFunc, func):
-    """
-    >>> from fontMath.mathFunctions import add, addPt
-    >>> guidelines = [
-    ...     (
-    ...         dict(x=1, y=3, angle=5, name="test", identifier="1", color="0,0,0,0"),
-    ...         dict(x=6, y=8, angle=10, name=None, identifier=None, color=None)
-    ...     )
-    ... ]
-    >>> expected = [
-    ...     dict(x=7, y=11, angle=15, name="test", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> _processMathOneGuidelines(guidelines, addPt, add) == expected
-    True
-    """
     result = []
     for guideline1, guideline2 in guidelinePairs:
         guideline = dict(guideline1)
@@ -261,19 +88,6 @@ def _processMathOneGuidelines(guidelinePairs, ptFunc, func):
     return result
 
 def _processMathTwoGuidelines(guidelines, factor, func):
-    """
-    >>> from fontMath.mathFunctions import mul
-    >>> guidelines = [
-    ...     dict(x=2, y=3, angle=5, name="test", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> expected = [
-    ...     dict(x=4, y=4.5, angle=3.75, name="test", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> result = _processMathTwoGuidelines(guidelines, (2, 1.5), mul)
-    >>> result[0]["angle"] = round(result[0]["angle"], 2)
-    >>> result == expected
-    True
-    """
     result = []
     for guideline in guidelines:
         guideline = dict(guideline)
@@ -285,17 +99,6 @@ def _processMathTwoGuidelines(guidelines, factor, func):
     return result
 
 def _roundGuidelines(guidelines, digits=None):
-    """
-    >>> guidelines = [
-    ...     dict(x=1.99, y=3.01, angle=5, name="test", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> expected = [
-    ...     dict(x=2, y=3, angle=5, name="test", identifier="1", color="0,0,0,0")
-    ... ]
-    >>> result = _roundGuidelines(guidelines)
-    >>> result == expected
-    True
-    """
     results = []
     for guideline in guidelines:
         guideline = dict(guideline)

--- a/Lib/fontMath/mathInfo.py
+++ b/Lib/fontMath/mathInfo.py
@@ -34,85 +34,11 @@ class MathInfo(object):
     # math with other info
 
     def __add__(self, otherInfo):
-        """
-        >>> info1 = MathInfo(_TestInfoObject())
-        >>> info2 = MathInfo(_TestInfoObject())
-        >>> info3 = info1 + info2
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info3, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v + v for v in value]
-        ...     else:
-        ...         expectedValue = value + value
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-
-        data subset (1st operand)
-        -------------------------
-        >>> info1 = MathInfo(_TestInfoObject(_testDataSubset))
-        >>> info2 = MathInfo(_TestInfoObject())
-        >>> info3 = info1 + info2
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info3, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v + v for v in value]
-        ...     else:
-        ...         expectedValue = value + value
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-
-        data subset (2nd operand)
-        -------------------------
-        >>> info1 = MathInfo(_TestInfoObject())
-        >>> info2 = MathInfo(_TestInfoObject(_testDataSubset))
-        >>> info3 = info1 + info2
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info3, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v + v for v in value]
-        ...     else:
-        ...         expectedValue = value + value
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-        """
         copiedInfo = self.copy()
         self._processMathOne(copiedInfo, otherInfo, addPt, add)
         return copiedInfo
 
     def __sub__(self, otherInfo):
-        """
-        >>> info1 = MathInfo(_TestInfoObject())
-        >>> info2 = MathInfo(_TestInfoObject())
-        >>> info3 = info1 - info2
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info3, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v - v for v in value]
-        ...     else:
-        ...         expectedValue = value - value
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-        """
         copiedInfo = self.copy()
         self._processMathOne(copiedInfo, otherInfo, subPt, sub)
         return copiedInfo
@@ -161,44 +87,6 @@ class MathInfo(object):
     # math with factor
 
     def __mul__(self, factor):
-        """
-        >>> info1 = MathInfo(_TestInfoObject())
-        >>> info2 = info1 * 2.5
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info2, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v * 2.5 for v in value]
-        ...     else:
-        ...         expectedValue = value * 2.5
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-
-        data subset
-        -----------
-        >>> info1 = MathInfo(_TestInfoObject(_testDataSubset))
-        >>> info2 = info1 * 2.5
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testDataSubset.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info2, attr)
-        ...     if attr == 'guidelines':
-        ...         guidelines = [_expandGuideline(guideline) for guideline in value]
-        ...         expectedValue = _processMathTwoGuidelines(guidelines, (2.5, 2.5), mul)
-        ...     elif isinstance(value, list):
-        ...         expectedValue = [v * 2.5 for v in value]
-        ...     else:
-        ...         expectedValue = value * 2.5
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-        """
         if not isinstance(factor, tuple):
             factor = (factor, factor)
         copiedInfo = self.copy()
@@ -208,23 +96,6 @@ class MathInfo(object):
     __rmul__ = __mul__
 
     def __div__(self, factor):
-        """
-        >>> info1 = MathInfo(_TestInfoObject())
-        >>> info2 = info1 / 2
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info2, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [v / 2 for v in value]
-        ...     else:
-        ...         expectedValue = value / 2
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-        """
         if not isinstance(factor, tuple):
             factor = (factor, factor)
         copiedInfo = self.copy()
@@ -272,40 +143,6 @@ class MathInfo(object):
     # special attributes
 
     def _processPostscriptWeightName(self, copiedInfo):
-        """
-        >>> info = MathInfo(_TestInfoObject())
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Medium'
-        >>> info.openTypeOS2WeightClass = 549
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Medium'
-        >>> info.openTypeOS2WeightClass = 550
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Semi-bold'
-        >>> info.openTypeOS2WeightClass = 450
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Medium'
-        >>> info.openTypeOS2WeightClass = 449
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Normal'
-        >>> info.openTypeOS2WeightClass = 0
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Thin'
-        >>> info.openTypeOS2WeightClass = -1000
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Thin'
-        >>> info.openTypeOS2WeightClass = 1000
-        >>> info._processPostscriptWeightName(info)
-        >>> info.postscriptWeightName
-        'Black'
-        """
         # handle postscriptWeightName by taking the value
         # of openTypeOS2WeightClass and getting the closest
         # value from the OS/2 specification.
@@ -332,47 +169,6 @@ class MathInfo(object):
     # ----------
 
     def round(self, digits=None):
-        """
-        >>> m = _TestInfoObject()
-        >>> m.ascender = 699.99
-        >>> m.descender = -199.99
-        >>> m.xHeight = 399.66
-        >>> m.postscriptSlantAngle = None
-        >>> m.postscriptStemSnapH = [80.1, 90.2]
-        >>> m.guidelines = [{'y': 100.99, 'x': None, 'angle': None, 'name': 'bar'}]
-        >>> m.italicAngle = -9.4
-        >>> m.postscriptBlueScale = 0.137
-        >>> info = MathInfo(m)
-        >>> info = info.round()
-        >>> info.ascender
-        700
-        >>> info.descender
-        -200
-        >>> info.xHeight
-        400
-        >>> m.italicAngle
-        -9.4
-        >>> m.postscriptBlueScale
-        0.137
-        >>> info.postscriptSlantAngle
-        >>> info.postscriptStemSnapH
-        [80, 90]
-        >>> [sorted(gl.items()) for gl in info.guidelines]
-        [[('angle', 0), ('name', 'bar'), ('x', 0), ('y', 101)]]
-        >>> written = {}
-        >>> expected = {}
-        >>> for attr, value in _testData.items():
-        ...     if value is None:
-        ...         continue
-        ...     written[attr] = getattr(info, attr)
-        ...     if isinstance(value, list):
-        ...         expectedValue = [_roundNumber(v) for v in value]
-        ...     else:
-        ...         expectedValue = _roundNumber(value)
-        ...     expected[attr] = expectedValue
-        >>> sorted(expected) == sorted(written)
-        True
-        """
         excludeFromRounding = ['postscriptBlueScale', 'italicAngle']
         copiedInfo = self.copy()
         # basic attributes
@@ -591,89 +387,6 @@ _postscriptWeightNameOptions = {
     800 : "Extra-bold",
     900 : "Black"
 }
-
-# ----
-# Test
-# ----
-
-_testData = dict(
-    # generic
-    unitsPerEm=1000,
-    descender=-200,
-    xHeight=400,
-    capHeight=650,
-    ascender=700,
-    italicAngle=0,
-    # head
-    openTypeHeadLowestRecPPEM=5,
-    # hhea
-    openTypeHheaAscender=700,
-    openTypeHheaDescender=-200,
-    openTypeHheaLineGap=200,
-    openTypeHheaCaretSlopeRise=1,
-    openTypeHheaCaretSlopeRun=1,
-    openTypeHheaCaretOffset=1,
-    # OS/2
-    openTypeOS2WidthClass=5,
-    openTypeOS2WeightClass=500,
-    openTypeOS2TypoAscender=700,
-    openTypeOS2TypoDescender=-200,
-    openTypeOS2TypoLineGap=200,
-    openTypeOS2WinAscent=700,
-    openTypeOS2WinDescent=-200,
-    openTypeOS2SubscriptXSize=300,
-    openTypeOS2SubscriptYSize=300,
-    openTypeOS2SubscriptXOffset=0,
-    openTypeOS2SubscriptYOffset=-200,
-    openTypeOS2SuperscriptXSize=300,
-    openTypeOS2SuperscriptYSize=300,
-    openTypeOS2SuperscriptXOffset=0,
-    openTypeOS2SuperscriptYOffset=500,
-    openTypeOS2StrikeoutSize=50,
-    openTypeOS2StrikeoutPosition=300,
-    # Vhea
-    openTypeVheaVertTypoAscender=700,
-    openTypeVheaVertTypoDescender=-200,
-    openTypeVheaVertTypoLineGap=200,
-    openTypeVheaCaretSlopeRise=1,
-    openTypeVheaCaretSlopeRun=1,
-    openTypeVheaCaretOffset=1,
-    # postscript
-    postscriptSlantAngle=0,
-    postscriptUnderlineThickness=100,
-    postscriptUnderlinePosition=-150,
-    postscriptBlueValues=[-10, 0, 400, 410, 650, 660, 700, 710],
-    postscriptOtherBlues=[-210, -200],
-    postscriptFamilyBlues=[-10, 0, 400, 410, 650, 660, 700, 710],
-    postscriptFamilyOtherBlues=[-210, -200],
-    postscriptStemSnapH=[80, 90],
-    postscriptStemSnapV=[110, 130],
-    postscriptBlueFuzz=1,
-    postscriptBlueShift=7,
-    postscriptBlueScale=0.039625,
-    postscriptDefaultWidthX=400,
-    postscriptNominalWidthX=400,
-    # guidelines
-    guidelines=None
-)
-
-_testDataSubset = dict(
-    # generic
-    unitsPerEm=1000,
-    descender=-200,
-    xHeight=None,
-    # postscript
-    postscriptBlueValues=[-10, 0, 400, 410, 650],
-    # guidelines
-    guidelines=[{'y': 100, 'x': None, 'angle': None, 'name': 'bar', 'identifier': '2'}]
-)
-
-class _TestInfoObject(object):
-
-    def __init__(self, data=_testData):
-        for attr, value in data.items():
-            setattr(self, attr, value)
-
 
 if __name__ == "__main__":
     import sys

--- a/Lib/fontMath/mathKerning.py
+++ b/Lib/fontMath/mathKerning.py
@@ -48,16 +48,6 @@ class MathKerning(object):
                     self._side2GroupMap[glyphName] = groupName
 
     def addTo(self, value):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 1,
-        ...     ("B", "B") : -1,
-        ... }
-        >>> obj = MathKerning(kerning)
-        >>> obj.addTo(1)
-        >>> sorted(obj.items())
-        [(('A', 'A'), 2), (('B', 'B'), 0)]
-        """
         for k, v in self._kerning.items():
             self._kerning[k] = v + value
 
@@ -81,35 +71,6 @@ class MathKerning(object):
         return pair in self._kerning
 
     def __getitem__(self, pair):
-        """
-        >>> kerning = {
-        ...     ("public.kern1.A", "public.kern2.A") : 1,
-        ...     ("A1", "public.kern2.A") : 2,
-        ...     ("public.kern1.A", "A2") : 3,
-        ...     ("A3", "A3") : 4,
-        ... }
-        >>> groups = {
-        ... "public.kern1.A" : ["A", "A1", "A2", "A3"],
-        ... "public.kern2.A" : ["A", "A1", "A2", "A3"],
-        ... }
-        >>> obj = MathKerning(kerning, groups)
-        >>> obj["A", "A"]
-        1
-        >>> obj["A1", "A"]
-        2
-        >>> obj["A", "A2"]
-        3
-        >>> obj["A3", "A3"]
-        4
-        >>> obj["X", "X"]
-        0
-        >>> obj["A3", "public.kern2.A"]
-        1
-        >>> sorted(obj.keys())[1]
-        ('A3', 'A3')
-        >>> sorted(obj.values())[3]
-        4
-        """
         if pair in self._kerning:
             return self._kerning[pair]
         side1, side2 = pair
@@ -141,41 +102,6 @@ class MathKerning(object):
     # ---------
 
     def guessPairType(self, pair):
-        """
-        >>> kerning = {
-        ...     ("public.kern1.A", "public.kern2.A") : 1,
-        ...     ("A1", "public.kern2.A") : 2,
-        ...     ("public.kern1.A", "A2") : 3,
-        ...     ("A3", "A3") : 4,
-        ...     ("public.kern1.B", "public.kern2.B") : 5,
-        ...     ("public.kern1.B", "B") : 6,
-        ...     ("public.kern1.C", "public.kern2.C") : 7,
-        ...     ("C", "public.kern2.C") : 8,
-        ... }
-        >>> groups = {
-        ... "public.kern1.A" : ["A", "A1", "A2", "A3"],
-        ... "public.kern2.A" : ["A", "A1", "A2", "A3"],
-        ... "public.kern1.B" : ["B"],
-        ... "public.kern2.B" : ["B"],
-        ... "public.kern1.C" : ["C"],
-        ... "public.kern2.C" : ["C"],
-        ... }
-        >>> obj = MathKerning(kerning, groups)
-        >>> obj.guessPairType(("public.kern1.A", "public.kern2.A"))
-        ('group', 'group')
-        >>> obj.guessPairType(("A1", "public.kern2.A"))
-        ('exception', 'group')
-        >>> obj.guessPairType(("public.kern1.A", "A2"))
-        ('group', 'exception')
-        >>> obj.guessPairType(("A3", "A3"))
-        ('exception', 'exception')
-        >>> obj.guessPairType(("A", "A"))
-        ('group', 'group')
-        >>> obj.guessPairType(("B", "B"))
-        ('group', 'exception')
-        >>> obj.guessPairType(("C", "C"))
-        ('exception', 'group')
-        """
         side1, side2 = pair
         if side1.startswith(side1Prefix):
             side1Group = side1
@@ -217,24 +143,6 @@ class MathKerning(object):
     # ----
 
     def copy(self):
-        """
-        >>> kerning1 = {
-        ...     ("A", "A") : 1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn2", "NotIn2") : 1,
-        ...     ("public.kern1.NotIn2", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups1 = {
-        ...     "public.kern1.NotIn1" : ["C"],
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> obj1 = MathKerning(kerning1, groups1)
-        >>> obj2 = obj1.copy()
-        >>> sorted(obj1.items()) == sorted(obj2.items())
-        True
-        """
         k = MathKerning(self._kerning)
         k._side1Groups = deepcopy(self._side1Groups)
         k._side2Groups = deepcopy(self._side2Groups)
@@ -249,109 +157,11 @@ class MathKerning(object):
     # math with other kerning
 
     def __add__(self, other):
-        """
-        >>> kerning1 = {
-        ...     ("A", "A") : 1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn2", "NotIn2") : 1,
-        ...     ("public.kern1.NotIn2", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups1 = {
-        ...     "public.kern1.NotIn1" : ["C"],
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> kerning2 = {
-        ...     ("A", "A") : -1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn1", "NotIn1") : 1,
-        ...     ("public.kern1.NotIn1", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups2 = {
-        ...     "public.kern1.NotIn2" : ["C"],
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 2), (('NotIn1', 'NotIn1'), 1), (('NotIn2', 'NotIn2'), 1), (('public.kern1.D', 'public.kern2.D'), 2), (('public.kern1.NotIn1', 'C'), 1), (('public.kern1.NotIn2', 'C'), 1)]
-        >>> sorted(obj.groups()["public.kern1.D"])
-        ['D', 'H']
-        >>> sorted(obj.groups()["public.kern2.D"])
-        ['D', 'H']
-
-        groups1 = groups2
-        -----------------
-        >>> kerning1 = {
-        ...     ("A", "A") : 1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn2", "NotIn2") : 1,
-        ...     ("public.kern1.NotIn2", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups1 = {
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> kerning2 = {
-        ...     ("A", "A") : -1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn1", "NotIn1") : 1,
-        ...     ("public.kern1.NotIn1", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups2 = {
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 2), (('NotIn1', 'NotIn1'), 1), (('NotIn2', 'NotIn2'), 1), (('public.kern1.D', 'public.kern2.D'), 2), (('public.kern1.NotIn1', 'C'), 1), (('public.kern1.NotIn2', 'C'), 1)]
-        >>> sorted(obj.groups()["public.kern1.D"])
-        ['D', 'H']
-        >>> sorted(obj.groups()["public.kern2.D"])
-        ['D', 'H']
-        """
         k = self._processMathOne(other, add)
         k.cleanup()
         return k
 
     def __sub__(self, other):
-        """
-        >>> kerning1 = {
-        ...     ("A", "A") : 1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn2", "NotIn2") : 1,
-        ...     ("public.kern1.NotIn2", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups1 = {
-        ...     "public.kern1.NotIn1" : ["C"],
-        ...     "public.kern1.D" : ["D", "H"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> kerning2 = {
-        ...     ("A", "A") : -1,
-        ...     ("B", "B") : 1,
-        ...     ("NotIn1", "NotIn1") : 1,
-        ...     ("public.kern1.NotIn1", "C") : 1,
-        ...     ("public.kern1.D", "public.kern2.D") : 1,
-        ... }
-        >>> groups2 = {
-        ...     "public.kern1.NotIn2" : ["C"],
-        ...     "public.kern1.D" : ["D"],
-        ...     "public.kern2.D" : ["D", "H"],
-        ... }
-        >>> obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
-        >>> sorted(obj.items())
-        [(('A', 'A'), 2), (('NotIn1', 'NotIn1'), -1), (('NotIn2', 'NotIn2'), 1), (('public.kern1.NotIn1', 'C'), -1), (('public.kern1.NotIn2', 'C'), 1)]
-        >>> sorted(obj.groups()["public.kern1.D"])
-        ['D', 'H']
-        >>> sorted(obj.groups()["public.kern2.D"])
-        ['D', 'H']
-        """
         k = self._processMathOne(other, sub)
         k.cleanup()
         return k
@@ -381,27 +191,6 @@ class MathKerning(object):
     # math with factor
 
     def __mul__(self, factor):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 0,
-        ...     ("B", "B") : 1,
-        ...     ("C2", "public.kern2.C") : 0,
-        ...     ("public.kern1.C", "public.kern2.C") : 2,
-        ... }
-        >>> groups = {
-        ...     "public.kern1.C" : ["C1", "C2"],
-        ...     "public.kern2.C" : ["C1", "C2"],
-        ... }
-        >>> obj = MathKerning(kerning, groups) * 2
-        >>> sorted(obj.items())
-        [(('B', 'B'), 2), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 4)]
-
-        tuple factor
-        ------------
-        >>> obj = MathKerning(kerning, groups) * (3, 2)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 3), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 6)]
-        """
         if isinstance(factor, tuple):
             factor = factor[0]
         k = self._processMathTwo(factor, mul)
@@ -409,27 +198,6 @@ class MathKerning(object):
         return k
 
     def __rmul__(self, factor):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 0,
-        ...     ("B", "B") : 1,
-        ...     ("C2", "public.kern2.C") : 0,
-        ...     ("public.kern1.C", "public.kern2.C") : 2,
-        ... }
-        >>> groups = {
-        ...     "public.kern1.C" : ["C1", "C2"],
-        ...     "public.kern2.C" : ["C1", "C2"],
-        ... }
-        >>> obj = 2 * MathKerning(kerning, groups)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 2), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 4)]
-
-        tuple factor
-        ------------
-        >>> obj = (3, 2) * MathKerning(kerning, groups)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 3), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 6)]
-        """
         if isinstance(factor, tuple):
             factor = factor[0]
         k = self._processMathTwo(factor, mul)
@@ -437,27 +205,6 @@ class MathKerning(object):
         return k
 
     def __div__(self, factor):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 0,
-        ...     ("B", "B") : 4,
-        ...     ("C2", "public.kern2.C") : 0,
-        ...     ("public.kern1.C", "public.kern2.C") : 4,
-        ... }
-        >>> groups = {
-        ...     "public.kern1.C" : ["C1", "C2"],
-        ...     "public.kern2.C" : ["C1", "C2"],
-        ... }
-        >>> obj = MathKerning(kerning, groups) / 2
-        >>> sorted(obj.items())
-        [(('B', 'B'), 2), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 2)]
-
-        tuple factor
-        ------------
-        >>> obj = MathKerning(kerning, groups) / (4, 2)
-        >>> sorted(obj.items())
-        [(('B', 'B'), 1), (('C2', 'public.kern2.C'), 0), (('public.kern1.C', 'public.kern2.C'), 1)]
-        """
         if isinstance(factor, tuple):
             factor = factor[0]
         k = self._processMathTwo(factor, div)
@@ -483,18 +230,6 @@ class MathKerning(object):
     # ---------
 
     def round(self, multiple=1):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 1.99,
-        ...     ("B", "B") : 4,
-        ...     ("C", "C") : 7,
-        ...     ("D", "D") : 9.01,
-        ... }
-        >>> obj = MathKerning(kerning)
-        >>> obj.round(5)
-        >>> sorted(obj.items())
-        [(('A', 'A'), 0), (('B', 'B'), 5), (('C', 'C'), 5), (('D', 'D'), 10)]
-        """
         multiple = float(multiple)
         for k, v in self._kerning.items():
             self._kerning[k] = int(round(int(round(v / multiple)) * multiple))
@@ -504,24 +239,6 @@ class MathKerning(object):
     # -------
 
     def cleanup(self):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 0,
-        ...     ("B", "B") : 1,
-        ...     ("C", "public.kern2.C") : 0,
-        ...     ("public.kern1.C", "public.kern2.C") : 1,
-        ...     ("D", "D") : 1.0,
-        ...     ("E", "E") : 1.2,
-        ... }
-        >>> groups = {
-        ...     "public.kern1.C" : ["C", "C1"],
-        ...     "public.kern2.C" : ["C", "C1"]
-        ... }
-        >>> obj = MathKerning(kerning, groups)
-        >>> obj.cleanup()
-        >>> sorted(obj.items())
-        [(('B', 'B'), 1), (('C', 'public.kern2.C'), 0), (('D', 'D'), 1), (('E', 'E'), 1.2), (('public.kern1.C', 'public.kern2.C'), 1)]
-        """
         for (side1, side2), v in list(self._kerning.items()):
             if int(v) == v:
                 v = int(v)
@@ -536,32 +253,6 @@ class MathKerning(object):
     # ----------
 
     def extractKerning(self, font):
-        """
-        >>> kerning = {
-        ...     ("A", "A") : 0,
-        ...     ("B", "B") : 1,
-        ...     ("C", "public.kern2.C") : 0,
-        ...     ("public.kern1.C", "public.kern2.C") : 1,
-        ...     ("D", "D") : 1.0,
-        ...     ("E", "E") : 1.2,
-        ... }
-        >>> groups = {
-        ...     "public.kern1.C" : ["C", "C1"],
-        ...     "public.kern2.C" : ["C", "C1"]
-        ... }
-        >>> from robofab.world import RFont
-        >>> font = RFont()
-        >>> font.kerning.asDict() == {}
-        True
-        >>> list(font.groups.items()) == []
-        True
-        >>> obj = MathKerning(kerning, groups)
-        >>> obj.extractKerning(font)
-        >>> sorted(font.kerning.asDict().items())
-        [(('B', 'B'), 1), (('D', 'D'), 1), (('E', 'E'), 1), (('public.kern1.C', 'public.kern2.C'), 1)]
-        >>> sorted(font.groups.items())
-        [('public.kern1.C', ['C', 'C1']), ('public.kern2.C', ['C', 'C1'])]
-        """
         font.kerning.clear()
         font.kerning.update(self._kerning)
         font.groups.update(self.groups())

--- a/Lib/fontMath/mathTransform.py
+++ b/Lib/fontMath/mathTransform.py
@@ -329,53 +329,6 @@ class MathTransform(object):
         angle2 = self._interpolate(self.angle2, other.angle2, y)
         return self.compose((translateX, translateY), (scaleX, scaleY), (angle1, angle2))
 
-# ----
-# Test
-# ----
-
-_testData = [
-    (
-    Transform().rotate(math.radians(0)),
-    Transform().rotate(math.radians(90))
-    ),
-
-    (
-    Transform().skew(math.radians(60), math.radians(10)),
-    Transform().rotate(math.radians(90))
-    ),
-
-    (
-    Transform().scale(.3, 1.3),
-    Transform().rotate(math.radians(90))
-    ),
-
-    (
-    Transform().scale(.3, 1.3).rotate(math.radians(-15)),
-    Transform().rotate(math.radians(90)).scale(.7, .3)
-    ),
-
-    (
-    Transform().translate(250, 250).rotate(math.radians(-15)).translate(-250, -250),
-    Transform().translate(0, 400).rotate(math.radians(80)).translate(-100, 0).rotate(math.radians(80)),
-    ),
-
-    (
-    Transform().skew(math.radians(50)).scale(1.5).rotate(math.radians(60)),
-    Transform().rotate(math.radians(90))
-    ),
-]
-
-def _testTransforms(_testData):
-    """
-    >>> for m1, m2 in _testData:
-    ...     m1, m2
-    (<Transform [1 0 0 1 0 0]>, <Transform [0 1 -1 0 0 0]>)
-    (<Transform [1.0 0.176326980708 1.73205080757 1.0 0 0]>, <Transform [0 1 -1 0 0 0]>)
-    (<Transform [0.3 0.0 0.0 1.3 0 0]>, <Transform [0 1 -1 0 0 0]>)
-    (<Transform [0.289777747887 -0.336464758633 0.0776457135308 1.25570357418 0.0 0.0]>, <Transform [0.0 0.7 -0.3 0.0 0 0]>)
-    (<Transform [0.965925826289 -0.258819045103 0.258819045103 0.965925826289 -56.1862178479 73.2233047034]>, <Transform [-0.939692620786 0.342020143326 -0.342020143326 -0.939692620786 -17.3648177667 301.519224699]>)
-    (<Transform [2.29813332936 1.29903810568 -0.405222911231 0.75 0.0 0.0]>, <Transform [0 1 -1 0 0 0]>)
-    """
 
 class FontMathWarning(Exception): pass
 
@@ -402,62 +355,6 @@ def _mathPolarDecomposeInterpolationTransformation(matrix1, matrix2, value):
     m3 = MathTransform().compose(m3.offset, m3.scale, m3.rotation)
     return tuple(m3)
 
-def _testFunctions(testData):
-    """
-    In this test various complex transformations are interpolated using 3 different methods:
-      - straight linear interpolation, the way glyphMath does it now.
-      - using the MathTransform interpolation method.
-      - using the ShallowTransform with an initial decompose and final compose.
-
-    >>> _testFunctions(_testData) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    FontMathWarning: Minor differences occured when comparing the interpolation functions.
-    """
-    value = random()
-    testFunctions = [
-        _polarDecomposeInterpolationTransformation,
-        _mathPolarDecomposeInterpolationTransformation,
-        _linearInterpolationTransformMatrix,
-    ]
-    for m1, m2 in testData:
-        results = []
-        for func in testFunctions:
-            r = func(m1, m2, value)
-            results.append(r)
-        if not results[0] == results[1]:
-            raise FontMathWarning("Minor differences occured when comparing the interpolation functions.")
-
-def _testWrapUnWrap(precision=12):
-    """
-    Wrap and unwrap a matrix with random values to establish rounding error
-
-    >>> _testWrapUnWrap()
-    """
-    t1 = []
-    for i in range(6):
-        t1.append(random())
-    m = matrixToMathTransform(t1)
-    t2 = mathTransformToMatrix(m)
-    if not sum([round(t1[i]-t2[i], precision) for i in range(len(t1))]) == 0:
-        raise FontMathWarning("Matrix round-tripping failed for precision value %s." % precision)
-
-def _testWrapUnWrapPrecision():
-    """
-    Wrap and unwrap should have no rounding errors at least up to a precision value of 12.
-    Rounding errors seem to start occuring at a precision value of 14.
-
-    >>> for p in range(5,13):
-    ...     for i in range(1000):
-    ...         _testWrapUnWrap(p)
-
-    >>> for p in range(14,16):
-    ...     for i in range(1000):
-    ...         _testWrapUnWrap(p) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    FontMathWarning: Matrix round-tripping failed for precision value ...
-    """
 
 if __name__ == "__main__":
     from random import random

--- a/Lib/fontMath/test/test_mathFunctions.py
+++ b/Lib/fontMath/test/test_mathFunctions.py
@@ -1,0 +1,70 @@
+import unittest
+from fontMath.mathFunctions import (
+    add, addPt, sub, subPt, mul, mulPt, div, divPt, factorAngle, _roundNumber
+)
+
+
+class MathFunctionsTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_add(self):
+        self.assertEqual(add(1, 2), 3)
+        self.assertEqual(add(3, -4), -1)
+        self.assertEqual(add(5, 0), 5)
+        self.assertEqual(add(6, 7), add(7, 6))
+
+    def test_addPt(self):
+        self.assertEqual(addPt((20, 230), (50, 40)), (70, 270))
+
+    def test_sub(self):
+        self.assertEqual(sub(10, 10), 0)
+        self.assertEqual(sub(10, -10), 20)
+        self.assertEqual(sub(-10, 10), -20)
+
+    def test_subPt(self):
+        self.assertEqual(subPt((20, 230), (50, 40)), (-30, 190))
+
+    def test_mul(self):
+        self.assertEqual(mul(1, 2), 2)
+        self.assertEqual(mul(3, -4), -12)
+        self.assertEqual(mul(10, 0), 0)
+        self.assertEqual(mul(5, 6), mul(6, 5))
+
+    def test_mulPt(self):
+        self.assertEqual(mulPt((15, 25), (2, 3)), (30, 75))
+
+    def test_div(self):
+        self.assertEqual(div(1, 2), 0.5)
+        with self.assertRaises(ZeroDivisionError):
+            div(10, 0)
+        self.assertEqual(div(12, -4), -3)
+
+    def test_divPt(self):
+        self.assertEqual(divPt((15, 75), (2, 3)), (7.5, 25.0))
+
+    def test_factorAngle(self):
+        f = factorAngle(5, (2, 1.5), mul)
+        self.assertEqual(round(f, 2), 3.75)
+
+    def test_roundNumber(self):
+        # round to integer:
+        self.assertEqual(_roundNumber(0), 0)
+        self.assertEqual(_roundNumber(0.1), 0)
+        self.assertEqual(_roundNumber(0.99), 1)
+        self.assertEqual(_roundNumber(0.499), 0)
+        self.assertEqual(_roundNumber(0.5), 1)
+        self.assertEqual(_roundNumber(-0.499), 0)
+        self.assertEqual(_roundNumber(-0.5), -1)
+
+    def test_roundNumber_to_float(self):
+        # round to float with specified decimals:
+        self.assertEqual(_roundNumber(0.3333, None), 0)
+        self.assertEqual(_roundNumber(0.3333, 0), 0.0)
+        self.assertEqual(_roundNumber(0.3333, 1), 0.3)
+        self.assertEqual(_roundNumber(0.3333, 2), 0.33)
+        self.assertEqual(_roundNumber(0.3333, 3), 0.333)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -1,0 +1,972 @@
+from __future__ import division
+import unittest
+from ufoLib.pointPen import AbstractPointPen
+from fontMath.mathFunctions import addPt, mulPt
+from fontMath.mathGlyph import (
+    MathGlyph, MathGlyphPen, FilterRedundantPointPen,
+    _processMathOneContours, _processMathTwoContours, _anchorTree,
+    _pairAnchors, _processMathOneAnchors, _processMathTwoAnchors,
+    _pairComponents, _processMathOneComponents, _processMathTwoComponents,
+    _expandImage, _compressImage, _pairImages, _processMathOneImage,
+    _processMathTwoImage, _processMathOneTransformation,
+    _processMathTwoTransformation, _roundContours, _roundTransformation,
+    _roundImage, _roundComponents, _roundAnchors
+)
+
+
+try:
+    basestring, xrange
+    range = xrange
+except NameError:
+    basestring = str
+
+
+class MathGlyphTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def _setupTestGlyph(self):
+        glyph = MathGlyph(None)
+        glyph.width = 0
+        glyph.height = 0
+        return glyph
+
+    def test_width_add(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 1
+        glyph2 = self._setupTestGlyph()
+        glyph2.width = 2
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.width, 3)
+
+    def test_width_sub(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 3
+        glyph2 = self._setupTestGlyph()
+        glyph2.width = 2
+        glyph3 = glyph1 - glyph2
+        self.assertEqual(glyph3.width, 1)
+
+    def test_width_mul(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 2
+        glyph2 = glyph1 * 3
+        self.assertEqual(glyph2.width, 6)
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 2
+        glyph2 = glyph1 * (3, 1)
+        self.assertEqual(glyph2.width, 6)
+
+    def test_width_div(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 7
+        glyph2 = glyph1 / 2
+        self.assertEqual(glyph2.width, 3.5)
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 7
+        glyph2 = glyph1 / (2, 1)
+        self.assertEqual(glyph2.width, 3.5)
+
+    def test_width_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.width = 6.99
+        glyph2 = glyph1.round()
+        self.assertEqual(glyph2.width, 7)
+
+    def test_height_add(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 1
+        glyph2 = self._setupTestGlyph()
+        glyph2.height = 2
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.height, 3)
+
+    def test_height_sub(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 3
+        glyph2 = self._setupTestGlyph()
+        glyph2.height = 2
+        glyph3 = glyph1 - glyph2
+        self.assertEqual(glyph3.height, 1)
+
+    def test_height_mul(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 2
+        glyph2 = glyph1 * 3
+        self.assertEqual(glyph2.height, 6)
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 2
+        glyph2 = glyph1 * (1, 3)
+        self.assertEqual(glyph2.height, 6)
+
+    def test_height_div(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 7
+        glyph2 = glyph1 / 2
+        self.assertEqual(glyph2.height, 3.5)
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 7
+        glyph2 = glyph1 / (1, 2)
+        self.assertEqual(glyph2.height, 3.5)
+
+    def test_height_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.height = 6.99
+        glyph2 = glyph1.round()
+        self.assertEqual(glyph2.height, 7)
+
+    def test_contours_add(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), True, "test", "1")])
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (1.55, 4.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (1.55, 4.1), True, "test", "1")])
+        ]
+        glyph3 = glyph1 + glyph2
+        expected = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 + 1.55, 3.1 + 4.1), False, "test",
+                          "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 + 1.55, 3.1 + 4.1), True, "test",
+                          "1")])
+        ]
+        self.assertEqual(glyph3.contours, expected)
+
+    def test_contours_sub(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), True, "test", "1")])
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (1.55, 4.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (1.55, 4.1), True, "test", "1")])
+        ]
+        glyph3 = glyph1 - glyph2
+        expected = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 - 1.55, 3.1 - 4.1), False, "test",
+                          "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 - 1.55, 3.1 - 4.1), True, "test",
+                          "1")])
+        ]
+        self.assertEqual(glyph3.contours, expected)
+
+    def test_contours_mul(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), True, "test", "1")])
+        ]
+        glyph2 = glyph1 * 2
+        expected = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 * 2, 3.1 * 2), False, "test",
+                          "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55 * 2, 3.1 * 2), True, "test",
+                          "1")])
+        ]
+        self.assertEqual(glyph2.contours, expected)
+
+    def test_contours_div(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (1, 3.4), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (2, 3.1), True, "test", "1")])
+        ]
+        glyph2 = glyph1 / 2
+        expected = [
+            dict(identifier="contour 1",
+                 points=[("line", (1/2, 3.4/2), False, "test",
+                          "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (2/2, 3.1/2), True, "test",
+                          "1")])
+        ]
+        self.assertEqual(glyph2.contours, expected)
+
+    def test_contours_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (0.55, 3.1), True, "test", "1")])
+        ]
+        glyph2 = glyph1.round()
+        expected = [
+            dict(identifier="contour 1",
+                 points=[("line", (1, 3), False, "test", "1")]),
+            dict(identifier="contour 1",
+                 points=[("line", (1, 3), True, "test", "1")])
+        ]
+        self.assertEqual(glyph2.contours, expected)
+
+    def test_components_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.components = [
+            dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5.1, 5.99),
+                 identifier="1"),
+        ]
+        glyph2 = glyph1.round()
+        expected = [
+            dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5, 6),
+                 identifier="1")
+        ]
+        self.assertEqual(glyph2.components, expected)
+
+    def test_guidelines_add_same_name_identifier_x_y_angle(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=3, y=4, angle=2)
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="foo", identifier="2", x=3, y=4, angle=2),
+            dict(name="foo", identifier="1", x=1, y=2, angle=1)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=2, y=4, angle=2),
+            dict(name="foo", identifier="2", x=6, y=8, angle=4)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_add_same_name_identifier(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=1, y=2, angle=2),
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="foo", identifier="2", x=3, y=4, angle=3),
+            dict(name="foo", identifier="1", x=3, y=4, angle=4)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=4, y=6, angle=5),
+            dict(name="foo", identifier="2", x=4, y=6, angle=5)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_add_same_name_x_y_angle(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=3, y=4, angle=2),
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="foo", identifier="3", x=3, y=4, angle=2),
+            dict(name="foo", identifier="4", x=1, y=2, angle=1)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=2, y=4, angle=2),
+            dict(name="foo", identifier="2", x=6, y=8, angle=4)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_add_same_identifier_x_y_angle(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=3, y=4, angle=2),
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="xxx", identifier="2", x=3, y=4, angle=2),
+            dict(name="yyy", identifier="1", x=1, y=2, angle=1)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=2, y=4, angle=2),
+            dict(name="bar", identifier="2", x=6, y=8, angle=4)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_add_same_name(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=1, y=2, angle=2),
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="bar", identifier="3", x=3, y=4, angle=3),
+            dict(name="foo", identifier="4", x=3, y=4, angle=4)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=4, y=6, angle=5),
+            dict(name="bar", identifier="2", x=4, y=6, angle=5)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_add_same_identifier(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=1, y=2, angle=2),
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="xxx", identifier="2", x=3, y=4, angle=3),
+            dict(name="yyy", identifier="1", x=3, y=4, angle=4)
+        ]
+        expected = [
+            dict(name="foo", identifier="1", x=4, y=6, angle=5),
+            dict(name="bar", identifier="2", x=4, y=6, angle=5)
+        ]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected)
+
+    def test_guidelines_mul(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(x=1, y=3, angle=5, name="test", identifier="1",
+                 color="0,0,0,0")
+        ]
+        glyph2 = glyph1 * 3
+        expected = [
+            dict(x=1 * 3, y=3 * 3, angle=5, name="test", identifier="1",
+                 color="0,0,0,0")
+        ]
+        self.assertEqual(glyph2.guidelines, expected)
+
+    def test_guidelines_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(x=1.99, y=3.01, angle=5, name="test", identifier="1",
+                 color="0,0,0,0")
+        ]
+        glyph2 = glyph1.round()
+        expected = [
+            dict(x=2, y=3, angle=5, name="test", identifier="1",
+                 color="0,0,0,0")
+        ]
+        self.assertEqual(glyph2.guidelines, expected)
+
+    def test_anchors_add(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.anchors = [
+            dict(x=1, y=-2, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.anchors = [
+            dict(x=3, y=-4, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph3 = glyph1 + glyph2
+        expected = [
+            dict(x=4, y=-6, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(glyph3.anchors, expected)
+
+    def test_anchors_sub(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.anchors = [
+            dict(x=1, y=-2, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.anchors = [
+            dict(x=3, y=-4, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph3 = glyph1 - glyph2
+        expected = [
+            dict(x=-2, y=2, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(glyph3.anchors, expected)
+
+    def test_anchors_mul(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.anchors = [
+            dict(x=1, y=-2, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph2 = glyph1 * 2
+        expected = [
+            dict(x=2, y=-4, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(glyph2.anchors, expected)
+
+    def test_anchors_div(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.anchors = [
+            dict(x=1, y=-2, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph2 = glyph1 / 2
+        expected = [
+            dict(x=0.5, y=-1, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(glyph2.anchors, expected)
+
+    def test_anchors_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.anchors = [
+            dict(x=99.9, y=-100.1, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        glyph2 = glyph1.round()
+        expected = [
+            dict(x=100, y=-100, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(glyph2.anchors, expected)
+
+    def test_image_round(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.image = dict(fileName="foo",
+                            transformation=(1, 2, 3, 4, 4.99, 6.01),
+                            color="0,0,0,0")
+        expected = dict(fileName="foo", transformation=(1, 2, 3, 4, 5, 6),
+                        color="0,0,0,0")
+        glyph2 = glyph1.round()
+        self.assertEqual(glyph2.image, expected)
+
+
+class MathGlyphPenTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_pen_with_lines(self):
+        pen = MathGlyphPen()
+        pen.beginPath(identifier="contour 1")
+        pen.addPoint((0,   100), "line", smooth=False, name="name 1",
+                     identifier="point 1")
+        pen.addPoint((100, 100), "line", smooth=False, name="name 2",
+                     identifier="point 2")
+        pen.addPoint((100, 0),   "line", smooth=False, name="name 3",
+                     identifier="point 3")
+        pen.addPoint((0,   0),   "line", smooth=False, name="name 4",
+                     identifier="point 4")
+        pen.endPath()
+        expected = [
+            ("curve", (0,   100), False, "name 1", "point 1"),
+            (None,    (0,   100), False, None,     None),
+            (None,    (100, 100), False, None,     None),
+            ("curve", (100, 100), False, "name 2", "point 2"),
+            (None,    (100, 100), False, None,     None),
+            (None,    (100, 0),   False, None,     None),
+            ("curve", (100, 0),   False, "name 3", "point 3"),
+            (None,    (100, 0),   False, None,     None),
+            (None,    (0,   0),   False, None,     None),
+            ("curve", (0,   0),   False, "name 4", "point 4"),
+            (None,    (0,   0),   False, None,     None),
+            (None,    (0,   100), False, None,     None),
+        ]
+        self.assertEqual(pen.contours[-1]["points"], expected)
+        self.assertEqual(pen.contours[-1]["identifier"], 'contour 1')
+
+    def test_pen_with_lines_and_curves(self):
+        pen = MathGlyphPen()
+        pen.beginPath(identifier="contour 1")
+        pen.addPoint((0,   50), "curve", smooth=False, name="name 1",
+                     identifier="point 1")
+        pen.addPoint((50, 100), "line",  smooth=False, name="name 2",
+                     identifier="point 2")
+        pen.addPoint((75, 100), None)
+        pen.addPoint((100, 75), None)
+        pen.addPoint((100, 50), "curve", smooth=True,  name="name 3",
+                     identifier="point 3")
+        pen.addPoint((100, 25), None)
+        pen.addPoint((75,   0), None)
+        pen.addPoint((50,   0), "curve", smooth=False, name="name 4",
+                     identifier="point 4")
+        pen.addPoint((25,   0), None)
+        pen.addPoint((0,   25), None)
+        pen.endPath()
+        expected = [
+            ("curve", (0,   50), False, "name 1", "point 1"),
+            (None,    (0,   50), False, None,     None),
+            (None,    (50, 100), False, None,     None),
+            ("curve", (50, 100), False, "name 2", "point 2"),
+            (None,    (75, 100), False, None,     None),
+            (None,    (100, 75), False, None,     None),
+            ("curve", (100, 50), True, "name 3", "point 3"),
+            (None,    (100, 25), False, None,     None),
+            (None,    (75,   0), False, None,     None),
+            ("curve", (50,   0), False, "name 4", "point 4"),
+            (None,    (25,   0), False, None,     None),
+            (None,    (0,   25), False, None,     None),
+        ]
+        self.assertEqual(pen.contours[-1]["points"], expected)
+        self.assertEqual(pen.contours[-1]["identifier"], 'contour 1')
+
+
+class _TestPointPen(AbstractPointPen):
+
+    def __init__(self):
+        self._text = []
+
+    def dump(self):
+        return "\n".join(self._text)
+
+    def _prep(self, i):
+        if isinstance(i, basestring):
+            i = "\"%s\"" % i
+        return str(i)
+
+    def beginPath(self, identifier=None, **kwargs):
+        self._text.append("beginPath(identifier=%s)" % self._prep(identifier))
+
+    def addPoint(self, pt, segmentType=None, smooth=False, name=None,
+                 identifier=None, **kwargs):
+        self._text.append(
+            "addPoint(%s, segmentType=%s, smooth=%s, name=%s, "
+            "identifier=%s)" % (
+                self._prep(pt),
+                self._prep(segmentType),
+                self._prep(smooth),
+                self._prep(name),
+                self._prep(identifier)
+                )
+        )
+
+    def endPath(self):
+        self._text.append("endPath()")
+
+    def addComponent(self, baseGlyph, transformation, identifier=None,
+                     **kwargs):
+        self._text.append(
+            "addComponent(baseGlyph=%s, transformation=%s, identifier=%s)" % (
+                self._prep(baseGlyph),
+                self._prep(transformation),
+                self._prep(identifier)
+                )
+        )
+
+
+class FilterRedundantPointPenTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_flushContour(self):
+        points = [
+            ("curve", (0,   100), False, "name 1", "point 1"),
+            (None,    (0,   100), False, None,     None),
+            (None,    (100, 100), False, None,     None),
+            ("curve", (100, 100), False, "name 2", "point 2"),
+            (None,    (100, 100), False, None,     None),
+            (None,    (100,   0), False, None,     None),
+            ("curve", (100,   0), False, "name 3", "point 3"),
+            (None,    (100,   0), False, None,     None),
+            (None,    (0,     0), False, None,     None),
+            ("curve", (0,     0), False, "name 4", "point 4"),
+            (None,    (0,     0), False, None,     None),
+            (None,    (0,   100), False, None,     None),
+        ]
+        testPen = _TestPointPen()
+        filterPen = FilterRedundantPointPen(testPen)
+        filterPen.beginPath(identifier="contour 1")
+        for segmentType, pt, smooth, name, identifier in points:
+            filterPen.addPoint(pt, segmentType=segmentType, smooth=smooth,
+                               name=name, identifier=identifier)
+        filterPen.endPath()
+        self.assertEqual(
+            testPen.dump(),
+            'beginPath(identifier="contour 1")\n'
+            'addPoint((0, 100), segmentType="line", smooth=False, '
+            'name="name 1", identifier="point 1")\n'
+            'addPoint((100, 100), segmentType="line", smooth=False, '
+            'name="name 2", identifier="point 2")\n'
+            'addPoint((100, 0), segmentType="line", smooth=False, '
+            'name="name 3", identifier="point 3")\n'
+            'addPoint((0, 0), segmentType="line", smooth=False, '
+            'name="name 4", identifier="point 4")\n'
+            'endPath()'
+        )
+
+
+class PrivateFuncsTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_processMathOneContours(self):
+        contours1 = [
+            dict(identifier="contour 1",
+                 points=[("line", (1, 3), False, "test", "1")])
+        ]
+        contours2 = [
+            dict(identifier=None, points=[(None, (4, 6), True, None, None)])
+        ]
+        self.assertEqual(
+            _processMathOneContours(contours1, contours2, addPt),
+            [
+                dict(identifier="contour 1",
+                     points=[("line", (5, 9), False, "test", "1")])
+            ]
+        )
+
+    def test_processMathTwoContours(self):
+        contours = [
+            dict(identifier="contour 1",
+                 points=[("line", (1, 3), False, "test", "1")])
+        ]
+        self.assertEqual(
+            _processMathTwoContours(contours, (2, 1.5), mulPt),
+            [
+                dict(identifier="contour 1",
+                     points=[("line", (2, 4.5), False, "test", "1")])
+            ]
+        )
+    True
+
+    def test_anchorTree(self):
+        anchors = [
+            dict(identifier="1", name="test", x=1, y=2, color=None),
+            dict(name="test", x=1, y=2, color=None),
+            dict(name="test", x=3, y=4, color=None),
+            dict(name="test", x=2, y=3, color=None),
+            dict(name="test 2", x=1, y=2, color=None),
+        ]
+        self.assertEqual(
+            _anchorTree(anchors),
+            {
+                "test": [
+                    ("1", 1, 2, None),
+                    (None, 1, 2, None),
+                    (None, 3, 4, None),
+                    (None, 2, 3, None),
+                ],
+                "test 2": [
+                    (None, 1, 2, None)
+                ]
+            }
+        )
+
+    def test_pairAnchors_matching_identifiers(self):
+        anchors1 = {
+            "test": [
+                (None, 1, 2, None),
+                ("identifier 1", 3, 4, None)
+            ]
+        }
+        anchors2 = {
+            "test": [
+                ("identifier 1", 1, 2, None),
+                (None, 3, 4, None)
+            ]
+        }
+        self.assertEqual(
+            _pairAnchors(anchors1, anchors2),
+            [
+                (
+                    dict(name="test", identifier=None, x=1, y=2, color=None),
+                    dict(name="test", identifier=None, x=3, y=4, color=None)
+                ),
+                (
+                    dict(name="test", identifier="identifier 1", x=3, y=4,
+                         color=None),
+                    dict(name="test", identifier="identifier 1", x=1, y=2,
+                         color=None)
+                )
+            ]
+        )
+
+    def test_pairAnchors_mismatched_identifiers(self):
+        anchors1 = {
+            "test": [
+                ("identifier 1", 3, 4, None)
+            ]
+        }
+        anchors2 = {
+            "test": [
+                ("identifier 2", 1, 2, None),
+            ]
+        }
+        self.assertEqual(
+            _pairAnchors(anchors1, anchors2),
+            [
+                (
+                    dict(name="test", identifier="identifier 1", x=3, y=4,
+                         color=None),
+                    dict(name="test", identifier="identifier 2", x=1, y=2,
+                         color=None)
+                )
+            ]
+        )
+
+    def test_processMathOneAnchors(self):
+        anchorPairs = [
+            (
+                dict(x=100, y=-100, name="foo", identifier="1",
+                     color="0,0,0,0"),
+                dict(x=200, y=-200, name="bar", identifier="2",
+                     color="1,1,1,1")
+            )
+        ]
+        self.assertEqual(
+            _processMathOneAnchors(anchorPairs, addPt),
+            [
+                dict(x=300, y=-300, name="foo", identifier="1",
+                     color="0,0,0,0")
+            ]
+        )
+
+    def test_processMathTwoAnchors(self):
+        anchors = [
+            dict(x=100, y=-100, name="foo", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(
+            _processMathTwoAnchors(anchors, (2, 1.5), mulPt),
+            [
+                dict(x=200, y=-150, name="foo", identifier="1",
+                     color="0,0,0,0")
+            ]
+        )
+
+    def test_pairComponents(self):
+        components1 = [
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier="1"),
+            dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier="1"),
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None)
+        ]
+        components2 = [
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None),
+            dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier="1"),
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier="1")
+        ]
+        self.assertEqual(
+            _pairComponents(components1, components2),
+            [
+                (
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier="1"),
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier="1")
+                ),
+                (
+                    dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier="1"),
+                    dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier="1")
+                ),
+                (
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None),
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None)
+                ),
+            ]
+        )
+
+        components1 = [
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None),
+            dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None)
+        ]
+        components2 = [
+            dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None),
+            dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                 identifier=None)
+        ]
+        self.assertEqual(
+            _pairComponents(components1, components2),
+            [
+                (
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None),
+                    dict(baseGlyph="A", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None)
+                ),
+                (
+                    dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None),
+                    dict(baseGlyph="B", transformation=(0, 0, 0, 0, 0, 0),
+                         identifier=None)
+                ),
+            ]
+        )
+
+    def test_processMathOneComponents(self):
+        components = [
+            (
+                dict(baseGlyph="A", transformation=(1,  3,  5,  7,  9, 11),
+                     identifier="1"),
+                dict(baseGlyph="A", transformation=(12, 14, 16, 18, 20, 22),
+                     identifier=None)
+            )
+        ]
+        self.assertEqual(
+            _processMathOneComponents(components, addPt),
+            [
+                dict(baseGlyph="A", transformation=(13, 17, 21, 25, 29, 33),
+                     identifier="1")
+            ]
+        )
+
+    def test_processMathTwoComponents(self):
+        components = [
+            dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5, 6),
+                 identifier="1"),
+        ]
+        self.assertEqual(
+            _processMathTwoComponents(components, (2, 1.5), mulPt),
+            [
+                dict(baseGlyph="A", transformation=(2, 4, 4.5, 6, 10, 9),
+                     identifier="1")
+            ]
+        )
+
+    def test_expandImage(self):
+        self.assertEqual(
+            _expandImage(None),
+            dict(fileName=None, transformation=(1, 0, 0, 1, 0, 0), color=None)
+        )
+        self.assertEqual(
+            _expandImage(dict(fileName="foo")),
+            dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0), color=None)
+        )
+
+    def test_compressImage(self):
+        self.assertEqual(
+            _compressImage(
+                dict(fileName="foo",
+                     transformation=(1, 0, 0, 1, 0, 0), color=None)),
+            dict(fileName="foo", color=None, xScale=1,
+                 xyScale=0, yxScale=0, yScale=1, xOffset=0, yOffset=0)
+        )
+
+    def test_pairImages(self):
+        image1 = dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0),
+                      color=None)
+        image2 = dict(fileName="foo", transformation=(2, 0, 0, 2, 0, 0),
+                      color="0,0,0,0")
+        self.assertEqual(
+            _pairImages(image1, image2),
+            (image1, image2)
+        )
+
+        image1 = dict(fileName="foo", transformation=(1, 0, 0, 1, 0, 0),
+                      color=None)
+        image2 = dict(fileName="bar", transformation=(1, 0, 0, 1, 0, 0),
+                      color=None)
+        self.assertEqual(
+            _pairImages(image1, image2),
+            ()
+        )
+
+    def test_processMathOneImage(self):
+        image1 = dict(fileName="foo", transformation=(1,  3,  5,  7,  9, 11),
+                      color="0,0,0,0")
+        image2 = dict(fileName="bar", transformation=(12, 14, 16, 18, 20, 22),
+                      color=None)
+        self.assertEqual(
+            _processMathOneImage((image1, image2), addPt),
+            dict(fileName="foo", transformation=(13, 17, 21, 25, 29, 33),
+                 color="0,0,0,0")
+        )
+
+    def test_processMathTwoImage(self):
+        image = dict(fileName="foo", transformation=(1, 2, 3, 4, 5, 6),
+                     color="0,0,0,0")
+        self.assertEqual(
+            _processMathTwoImage(image, (2, 1.5), mulPt),
+            dict(fileName="foo", transformation=(2, 4, 4.5, 6, 10, 9),
+                 color="0,0,0,0")
+        )
+
+    def test_processMathOneTransformation(self):
+        transformation1 = (1,  3,  5,  7,  9, 11)
+        transformation2 = (12, 14, 16, 18, 20, 22)
+        self.assertEqual(
+            _processMathOneTransformation(transformation1, transformation2,
+                                          addPt),
+            (13, 17, 21, 25, 29, 33)
+        )
+
+    def test_processMathTwoTransformation(self):
+        transformation = (1, 2, 3, 4, 5, 6)
+        self.assertEqual(
+            _processMathTwoTransformation(transformation, (2, 1.5), mulPt),
+            (2, 4, 4.5, 6, 10, 9)
+        )
+
+    def test_roundContours(self):
+        contour = [
+            dict(identifier="contour 1", points=[("line", (0.55, 3.1), False,
+                 "test", "1")]),
+            dict(identifier="contour 1", points=[("line", (0.55, 3.1), True,
+                 "test", "1")])
+        ]
+        self.assertEqual(
+            _roundContours(contour),
+            [
+                dict(identifier="contour 1", points=[("line", (1, 3), False,
+                     "test", "1")]),
+                dict(identifier="contour 1", points=[("line", (1, 3), True,
+                     "test", "1")])
+            ]
+        )
+
+    def test_roundTransformation(self):
+        transformation = (1, 2, 3, 4, 4.99, 6.01)
+        self.assertEqual(
+            _roundTransformation(transformation),
+            (1, 2, 3, 4, 5, 6)
+        )
+
+    def test_roundImage(self):
+        image = dict(fileName="foo", transformation=(1, 2, 3, 4, 4.99, 6.01),
+                     color="0,0,0,0")
+        self.assertEqual(
+            _roundImage(image),
+            dict(fileName="foo", transformation=(1, 2, 3, 4, 5, 6),
+                 color="0,0,0,0")
+        )
+
+    def test_roundComponents(self):
+        components = [
+            dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5.1, 5.99),
+                 identifier="1"),
+        ]
+        self.assertEqual(
+            _roundComponents(components),
+            [
+                dict(baseGlyph="A", transformation=(1, 2, 3, 4, 5, 6),
+                     identifier="1")
+            ]
+        )
+
+    def test_roundAnchors(self):
+        anchors = [
+            dict(x=99.9, y=-100.1, name="foo", identifier="1",
+                 color="0,0,0,0")
+        ]
+        self.assertEqual(
+            _roundAnchors(anchors),
+            [
+                dict(x=100, y=-100, name="foo", identifier="1",
+                     color="0,0,0,0")
+            ]
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontMath/test/test_mathGuideline.py
+++ b/Lib/fontMath/test/test_mathGuideline.py
@@ -1,0 +1,229 @@
+import unittest
+from fontMath.mathFunctions import add, addPt, mul
+from fontMath.mathGuideline import (
+    _expandGuideline, _compressGuideline, _pairGuidelines,
+    _processMathOneGuidelines, _processMathTwoGuidelines, _roundGuidelines
+)
+
+
+class MathGuidelineTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_expandGuideline(self):
+        guideline = dict(x=100, y=None, angle=None)
+        self.assertEqual(
+            sorted(_expandGuideline(guideline).items()),
+            [('angle', 90), ('x', 100), ('y', 0)]
+        )
+
+        guideline = dict(y=100, x=None, angle=None)
+        self.assertEqual(
+            sorted(_expandGuideline(guideline).items()),
+            [('angle', 0), ('x', 0), ('y', 100)]
+        )
+
+    def test_compressGuideline(self):
+        guideline = dict(x=100, y=0, angle=90)
+        self.assertEqual(
+            sorted(_compressGuideline(guideline).items()),
+            [('angle', None), ('x', 100), ('y', None)]
+        )
+
+        guideline = dict(x=100, y=0, angle=270)
+        self.assertEqual(
+            sorted(_compressGuideline(guideline).items()),
+            [('angle', None), ('x', 100), ('y', None)]
+        )
+
+        guideline = dict(y=100, x=0, angle=0)
+        self.assertEqual(
+            sorted(_compressGuideline(guideline).items()),
+            [('angle', None), ('x', None), ('y', 100)]
+        )
+
+        guideline = dict(y=100, x=0, angle=180)
+        self.assertEqual(
+            sorted(_compressGuideline(guideline).items()),
+            [('angle', None), ('x', None), ('y', 100)]
+        )
+
+    def test_pairGuidelines_name_identifier_x_y_angle(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=3, y=4, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="foo", identifier="2", x=3, y=4, angle=2),
+            dict(name="foo", identifier="1", x=1, y=2, angle=1)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="foo", identifier="1", x=1, y=2, angle=1)
+            ),
+            (
+                dict(name="foo", identifier="2", x=3, y=4, angle=2),
+                dict(name="foo", identifier="2", x=3, y=4, angle=2)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_pairGuidelines_name_identifier(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=1, y=2, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="foo", identifier="2", x=3, y=4, angle=3),
+            dict(name="foo", identifier="1", x=3, y=4, angle=4)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="foo", identifier="1", x=3, y=4, angle=4)
+            ),
+            (
+                dict(name="foo", identifier="2", x=1, y=2, angle=2),
+                dict(name="foo", identifier="2", x=3, y=4, angle=3)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_pairGuidelines_name_x_y_angle(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="foo", identifier="2", x=3, y=4, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="foo", identifier="3", x=3, y=4, angle=2),
+            dict(name="foo", identifier="4", x=1, y=2, angle=1)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="foo", identifier="4", x=1, y=2, angle=1)
+            ),
+            (
+                dict(name="foo", identifier="2", x=3, y=4, angle=2),
+                dict(name="foo", identifier="3", x=3, y=4, angle=2)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_pairGuidelines_identifier_x_y_angle(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=3, y=4, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="xxx", identifier="2", x=3, y=4, angle=2),
+            dict(name="yyy", identifier="1", x=1, y=2, angle=1)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="yyy", identifier="1", x=1, y=2, angle=1)
+            ),
+            (
+                dict(name="bar", identifier="2", x=3, y=4, angle=2),
+                dict(name="xxx", identifier="2", x=3, y=4, angle=2)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_pairGuidelines_name(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=1, y=2, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="bar", identifier="3", x=3, y=4, angle=3),
+            dict(name="foo", identifier="4", x=3, y=4, angle=4)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="foo", identifier="4", x=3, y=4, angle=4)
+            ),
+            (
+                dict(name="bar", identifier="2", x=1, y=2, angle=2),
+                dict(name="bar", identifier="3", x=3, y=4, angle=3)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_pairGuidelines_identifier(self):
+        guidelines1 = [
+            dict(name="foo", identifier="1", x=1, y=2, angle=1),
+            dict(name="bar", identifier="2", x=1, y=2, angle=2),
+        ]
+        guidelines2 = [
+            dict(name="xxx", identifier="2", x=3, y=4, angle=3),
+            dict(name="yyy", identifier="1", x=3, y=4, angle=4)
+        ]
+        expected = [
+            (
+                dict(name="foo", identifier="1", x=1, y=2, angle=1),
+                dict(name="yyy", identifier="1", x=3, y=4, angle=4)
+            ),
+            (
+                dict(name="bar", identifier="2", x=1, y=2, angle=2),
+                dict(name="xxx", identifier="2", x=3, y=4, angle=3)
+            )
+        ]
+        self.assertEqual(
+            _pairGuidelines(guidelines1, guidelines2),
+            expected
+        )
+
+    def test_processMathOneGuidelines(self):
+        guidelines = [
+            (
+                dict(x=1, y=3, angle=5, name="test", identifier="1", color="0,0,0,0"),
+                dict(x=6, y=8, angle=10, name=None, identifier=None, color=None)
+            )
+        ]
+        expected = [
+            dict(x=7, y=11, angle=15, name="test", identifier="1", color="0,0,0,0")
+        ]
+        self.assertEqual(
+            _processMathOneGuidelines(guidelines, addPt, add),
+            expected
+        )
+
+    def test_processMathTwoGuidelines(self):
+        guidelines = [
+            dict(x=2, y=3, angle=5, name="test", identifier="1", color="0,0,0,0")
+        ]
+        expected = [
+            dict(x=4, y=4.5, angle=3.75, name="test", identifier="1", color="0,0,0,0")
+        ]
+        result = _processMathTwoGuidelines(guidelines, (2, 1.5), mul)
+        result[0]["angle"] = round(result[0]["angle"], 2)
+        self.assertEqual(result, expected)
+
+    def test_roundGuidelines(self):
+        guidelines = [
+            dict(x=1.99, y=3.01, angle=5, name="test", identifier="1", color="0,0,0,0")
+        ]
+        expected = [
+            dict(x=2, y=3, angle=5, name="test", identifier="1", color="0,0,0,0")
+        ]
+        result = _roundGuidelines(guidelines)
+        self.assertEqual(result, expected)

--- a/Lib/fontMath/test/test_mathInfo.py
+++ b/Lib/fontMath/test/test_mathInfo.py
@@ -1,0 +1,287 @@
+import unittest
+from fontMath.mathFunctions import _roundNumber
+from fontMath.mathInfo import MathInfo
+
+
+class MathInfoTest(unittest.TestCase):
+
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        self.maxDiff = None
+
+    def test_add(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = MathInfo(_TestInfoObject())
+        info3 = info1 + info2
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info3, attr)
+            if isinstance(value, list):
+                expectedValue = [v + v for v in value]
+            else:
+                expectedValue = value + value
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_add_data_subset_1st_operand(self):
+        info1 = MathInfo(_TestInfoObject(_testDataSubset))
+        info2 = MathInfo(_TestInfoObject())
+        info3 = info1 + info2
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info3, attr)
+            if isinstance(value, list):
+                expectedValue = [v + v for v in value]
+            else:
+                expectedValue = value + value
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected), sorted(written))
+        # self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_add_data_subset_2nd_operand(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = MathInfo(_TestInfoObject(_testDataSubset))
+        info3 = info1 + info2
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info3, attr)
+            if isinstance(value, list):
+                expectedValue = [v + v for v in value]
+            else:
+                expectedValue = value + value
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected), sorted(written))
+        # self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_sub(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = MathInfo(_TestInfoObject())
+        info3 = info1 - info2
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info3, attr)
+            if isinstance(value, list):
+                expectedValue = [v - v for v in value]
+            else:
+                expectedValue = value - value
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_mul(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = info1 * 2.5
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info2, attr)
+            if isinstance(value, list):
+                expectedValue = [v * 2.5 for v in value]
+            else:
+                expectedValue = value * 2.5
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_mul_data_subset(self):
+        info1 = MathInfo(_TestInfoObject(_testDataSubset))
+        info2 = info1 * 2.5
+        written = {}
+        expected = {}
+        for attr, value in _testDataSubset.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info2, attr)
+        expected = {"descender": -500.0,
+                    "guidelines": [{"y": 250.0, "x": 0.0, "identifier": "2",
+                                    "angle": 0.0, "name": "bar"}],
+                    "postscriptBlueValues": [-25.0, 0.0, 1000.0, 1025.0, 1625.0],
+                    "unitsPerEm": 2500.0}
+        self.assertEqual(sorted(expected.items()), sorted(written.items()))
+
+    def test_div(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = info1 / 2
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info2, attr)
+            if isinstance(value, list):
+                expectedValue = [v / 2 for v in value]
+            else:
+                expectedValue = value / 2
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected), sorted(written))
+
+    def test_weight_name(self):
+        info1 = MathInfo(_TestInfoObject())
+        info2 = MathInfo(_TestInfoObject())
+        info2.openTypeOS2WeightClass = 0
+        info3 = info1 + info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 500)
+        self.assertEqual(info3.postscriptWeightName, "Medium")
+        info2.openTypeOS2WeightClass = 49
+        info3 = info1 + info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 549)
+        self.assertEqual(info3.postscriptWeightName, "Medium")
+        info2.openTypeOS2WeightClass = 50
+        info3 = info1 + info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 550)
+        self.assertEqual(info3.postscriptWeightName, "Semi-bold")
+        info2.openTypeOS2WeightClass = 50
+        info3 = info1 - info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 450)
+        self.assertEqual(info3.postscriptWeightName, "Medium")
+        info2.openTypeOS2WeightClass = 51
+        info3 = info1 - info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 449)
+        self.assertEqual(info3.postscriptWeightName, "Normal")
+        info2.openTypeOS2WeightClass = 500
+        info3 = info1 - info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 0)
+        self.assertEqual(info3.postscriptWeightName, "Thin")
+        info2.openTypeOS2WeightClass = 1500
+        info3 = info1 - info2
+        self.assertEqual(info3.openTypeOS2WeightClass, -1000)
+        self.assertEqual(info3.postscriptWeightName, "Thin")
+        info2.openTypeOS2WeightClass = 500
+        info3 = info1 + info2
+        self.assertEqual(info3.openTypeOS2WeightClass, 1000)
+        self.assertEqual(info3.postscriptWeightName, "Black")
+
+    def test_round(self):
+        m = _TestInfoObject()
+        m.ascender = 699.99
+        m.descender = -199.99
+        m.xHeight = 399.66
+        m.postscriptSlantAngle = None
+        m.postscriptStemSnapH = [80.1, 90.2]
+        m.guidelines = [{'y': 100.99, 'x': None, 'angle': None, 'name': 'bar'}]
+        m.italicAngle = -9.4
+        m.postscriptBlueScale = 0.137
+        info = MathInfo(m)
+        info = info.round()
+        self.assertEqual(info.ascender, 700)
+        self.assertEqual(info.descender, -200)
+        self.assertEqual(info.xHeight, 400)
+        self.assertEqual(m.italicAngle, -9.4)
+        self.assertEqual(m.postscriptBlueScale, 0.137)
+        self.assertIsNone(info.postscriptSlantAngle)
+        self.assertEqual(info.postscriptStemSnapH, [80, 90])
+        self.assertEqual(
+            [sorted(gl.items()) for gl in info.guidelines],
+            [[('angle', 0), ('name', 'bar'), ('x', 0), ('y', 101)]]
+        )
+        written = {}
+        expected = {}
+        for attr, value in _testData.items():
+            if value is None:
+                continue
+            written[attr] = getattr(info, attr)
+            if isinstance(value, list):
+                expectedValue = [_roundNumber(v) for v in value]
+            else:
+                expectedValue = _roundNumber(value)
+            expected[attr] = expectedValue
+        self.assertEqual(sorted(expected), sorted(written))
+# ----
+# Test Data
+# ----
+
+_testData = dict(
+    # generic
+    unitsPerEm=1000,
+    descender=-200,
+    xHeight=400,
+    capHeight=650,
+    ascender=700,
+    italicAngle=0,
+    # head
+    openTypeHeadLowestRecPPEM=5,
+    # hhea
+    openTypeHheaAscender=700,
+    openTypeHheaDescender=-200,
+    openTypeHheaLineGap=200,
+    openTypeHheaCaretSlopeRise=1,
+    openTypeHheaCaretSlopeRun=1,
+    openTypeHheaCaretOffset=1,
+    # OS/2
+    openTypeOS2WidthClass=5,
+    openTypeOS2WeightClass=500,
+    openTypeOS2TypoAscender=700,
+    openTypeOS2TypoDescender=-200,
+    openTypeOS2TypoLineGap=200,
+    openTypeOS2WinAscent=700,
+    openTypeOS2WinDescent=-200,
+    openTypeOS2SubscriptXSize=300,
+    openTypeOS2SubscriptYSize=300,
+    openTypeOS2SubscriptXOffset=0,
+    openTypeOS2SubscriptYOffset=-200,
+    openTypeOS2SuperscriptXSize=300,
+    openTypeOS2SuperscriptYSize=300,
+    openTypeOS2SuperscriptXOffset=0,
+    openTypeOS2SuperscriptYOffset=500,
+    openTypeOS2StrikeoutSize=50,
+    openTypeOS2StrikeoutPosition=300,
+    # Vhea
+    openTypeVheaVertTypoAscender=700,
+    openTypeVheaVertTypoDescender=-200,
+    openTypeVheaVertTypoLineGap=200,
+    openTypeVheaCaretSlopeRise=1,
+    openTypeVheaCaretSlopeRun=1,
+    openTypeVheaCaretOffset=1,
+    # postscript
+    postscriptSlantAngle=0,
+    postscriptUnderlineThickness=100,
+    postscriptUnderlinePosition=-150,
+    postscriptBlueValues=[-10, 0, 400, 410, 650, 660, 700, 710],
+    postscriptOtherBlues=[-210, -200],
+    postscriptFamilyBlues=[-10, 0, 400, 410, 650, 660, 700, 710],
+    postscriptFamilyOtherBlues=[-210, -200],
+    postscriptStemSnapH=[80, 90],
+    postscriptStemSnapV=[110, 130],
+    postscriptBlueFuzz=1,
+    postscriptBlueShift=7,
+    postscriptBlueScale=0.039625,
+    postscriptDefaultWidthX=400,
+    postscriptNominalWidthX=400,
+    # guidelines
+    guidelines=None
+)
+
+_testDataSubset = dict(
+    # generic
+    unitsPerEm=1000,
+    descender=-200,
+    xHeight=None,
+    # postscript
+    postscriptBlueValues=[-10, 0, 400, 410, 650],
+    # guidelines
+    guidelines=[
+        {'y': 100, 'x': None, 'angle': None, 'name': 'bar', 'identifier': '2'}
+    ]
+)
+
+
+class _TestInfoObject(object):
+
+    def __init__(self, data=_testData):
+        for attr, value in data.items():
+            setattr(self, attr, value)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontMath/test/test_mathKerning.py
+++ b/Lib/fontMath/test/test_mathKerning.py
@@ -1,0 +1,412 @@
+from __future__ import unicode_literals
+import unittest
+from fontMath.mathKerning import MathKerning
+
+
+class TestKerning(object):
+    """Mockup Kerning class"""
+    def __init__(self):
+        self._kerning = {}
+
+    def clear(self):
+        self._kerning = {}
+
+    def asDict(self, returnIntegers=True):
+        if not returnIntegers:
+            return self._kerning
+        kerning = {k: int(round(v)) for (k, v) in self._kerning.items()}
+        return kerning
+
+    def update(self, kerningDict):
+        self._kerning = {k: v for (k, v) in kerningDict.items()
+                         if v != 0}
+
+
+class TestFont(object):
+    """Mockup Font class"""
+    def __init__(self):
+        self.kerning = TestKerning()
+        self.groups = {}
+
+
+class MathKerningTest(unittest.TestCase):
+
+    def test_addTo(self):
+        kerning = {
+            ("A", "A"): 1,
+            ("B", "B"): -1,
+        }
+        obj = MathKerning(kerning)
+        obj.addTo(1)
+        self.assertEqual(sorted(obj.items()),
+                         [(('A', 'A'), 2), (('B', 'B'), 0)])
+
+    def test_getitem(self):
+        kerning = {
+            ("public.kern1.A", "public.kern2.A"): 1,
+            ("A1", "public.kern2.A"): 2,
+            ("public.kern1.A", "A2"): 3,
+            ("A3", "A3"): 4,
+        }
+        groups = {
+            "public.kern1.A": ["A", "A1", "A2", "A3"],
+            "public.kern2.A": ["A", "A1", "A2", "A3"],
+        }
+        obj = MathKerning(kerning, groups)
+        self.assertEqual(obj["A", "A"], 1)
+        self.assertEqual(obj["A1", "A"], 2)
+        self.assertEqual(obj["A", "A2"], 3)
+        self.assertEqual(obj["A3", "A3"], 4)
+        self.assertEqual(obj["X", "X"], 0)
+        self.assertEqual(obj["A3", "public.kern2.A"], 1)
+        self.assertEqual(sorted(obj.keys())[1], ("A3", "A3"))
+        self.assertEqual(sorted(obj.values())[3], 4)
+
+    def test_guessPairType(self):
+        kerning = {
+            ("public.kern1.A", "public.kern2.A"): 1,
+            ("A1", "public.kern2.A"): 2,
+            ("public.kern1.A", "A2"): 3,
+            ("A3", "A3"): 4,
+            ("public.kern1.B", "public.kern2.B"): 5,
+            ("public.kern1.B", "B"): 6,
+            ("public.kern1.C", "public.kern2.C"): 7,
+            ("C", "public.kern2.C"): 8,
+        }
+        groups = {
+            "public.kern1.A": ["A", "A1", "A2", "A3"],
+            "public.kern2.A": ["A", "A1", "A2", "A3"],
+            "public.kern1.B": ["B"],
+            "public.kern2.B": ["B"],
+            "public.kern1.C": ["C"],
+            "public.kern2.C": ["C"],
+        }
+        obj = MathKerning(kerning, groups)
+        self.assertEqual(obj.guessPairType(("public.kern1.A", "public.kern2.A")),
+                         ('group', 'group'))
+        self.assertEqual(obj.guessPairType(("A1", "public.kern2.A")),
+                         ('exception', 'group'))
+        self.assertEqual(obj.guessPairType(("public.kern1.A", "A2")),
+                         ('group', 'exception'))
+        self.assertEqual(obj.guessPairType(("A3", "A3")),
+                         ('exception', 'exception'))
+        self.assertEqual(obj.guessPairType(("A", "A")),
+                         ('group', 'group'))
+        self.assertEqual(obj.guessPairType(("B", "B")),
+                         ('group', 'exception'))
+        self.assertEqual(obj.guessPairType(("C", "C")),
+                         ('exception', 'group'))
+
+    def test_copy(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.NotIn1": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj1 = MathKerning(kerning1, groups1)
+        obj2 = obj1.copy()
+        self.assertEqual(sorted(obj1.items()), sorted(obj2.items()))
+
+    def test_add(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.NotIn1": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.NotIn1", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.NotIn2": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('NotIn1', 'NotIn1'), 1),
+             (('NotIn2', 'NotIn2'), 1),
+             (('public.kern1.D', 'public.kern2.D'), 2),
+             (('public.kern1.NotIn1', 'C'), 1),
+             (('public.kern1.NotIn2', 'C'), 1)])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern1.D"]),
+            ['D', 'H'])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern2.D"]),
+            ['D', 'H'])
+
+    def test_add_same_groups(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.NotIn1", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('NotIn1', 'NotIn1'), 1),
+             (('NotIn2', 'NotIn2'), 1),
+             (('public.kern1.D', 'public.kern2.D'), 2),
+             (('public.kern1.NotIn1', 'C'), 1),
+             (('public.kern1.NotIn2', 'C'), 1)])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern1.D"]),
+            ['D', 'H'])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern2.D"]),
+            ['D', 'H'])
+
+    def test_sub(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.NotIn1": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.NotIn1", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.NotIn2": ["C"],
+            "public.kern1.D": ["D"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('A', 'A'), 2),
+             (('NotIn1', 'NotIn1'), -1),
+             (('NotIn2', 'NotIn2'), 1),
+             (('public.kern1.NotIn1', 'C'), -1),
+             (('public.kern1.NotIn2', 'C'), 1)])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern1.D"]),
+            ['D', 'H'])
+        self.assertEqual(
+            sorted(obj.groups()["public.kern2.D"]),
+            ['D', 'H'])
+
+    def test_mul(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 2,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = MathKerning(kerning, groups) * 2
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 4)])
+
+    def test_mul_tuple_factor(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 2,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = MathKerning(kerning, groups) * (3, 2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 3),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 6)])
+
+    def test_rmul(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 2,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = 2 * MathKerning(kerning, groups)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 4)])
+
+    def test_rmul_tuple_factor(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 2,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = (3, 2) * MathKerning(kerning, groups)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 3),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 6)])
+
+    def test_div(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = MathKerning(kerning, groups) / 2
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 2)])
+
+    def test_div_tuple_factor(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        obj = MathKerning(kerning, groups) / (4, 2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 1),
+             (('C2', 'public.kern2.C'), 0),
+             (('public.kern1.C', 'public.kern2.C'), 1)])
+
+    def test_round(self):
+        kerning = {
+            ("A", "A"): 1.99,
+            ("B", "B"): 4,
+            ("C", "C"): 7,
+            ("D", "D"): 9.01,
+        }
+        obj = MathKerning(kerning)
+        obj.round(5)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('A', 'A'), 0), (('B', 'B'), 5),
+             (('C', 'C'), 5), (('D', 'D'), 10)])
+
+    def test_cleanup(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 1,
+            ("D", "D"): 1.0,
+            ("E", "E"): 1.2,
+        }
+        groups = {
+            "public.kern1.C": ["C", "C1"],
+            "public.kern2.C": ["C", "C1"]
+        }
+        obj = MathKerning(kerning, groups)
+        obj.cleanup()
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 1),
+             (('C', 'public.kern2.C'), 0),
+             (('D', 'D'), 1),
+             (('E', 'E'), 1.2),
+             (('public.kern1.C', 'public.kern2.C'), 1)])
+
+    def test_extractKerning(self):
+        kerning = {
+            ("A", "A"): 0,
+            ("B", "B"): 1,
+            ("C", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 1,
+            ("D", "D"): 1.0,
+            ("E", "E"): 1.2,
+        }
+        groups = {
+            "public.kern1.C": ["C", "C1"],
+            "public.kern2.C": ["C", "C1"]
+        }
+        font = TestFont()
+        self.assertEqual(font.kerning.asDict(), {})
+        self.assertEqual(list(font.groups.items()), [])
+        obj = MathKerning(kerning, groups)
+        obj.extractKerning(font)
+        self.assertEqual(
+            sorted(font.kerning.asDict().items()),
+            [(('B', 'B'), 1),
+             (('D', 'D'), 1), (('E', 'E'), 1),
+             (('public.kern1.C', 'public.kern2.C'), 1)])
+        self.assertEqual(
+            sorted(font.groups.items()),
+            [('public.kern1.C', ['C', 'C1']),
+             ('public.kern2.C', ['C', 'C1'])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontMath/test/test_mathTransform.py
+++ b/Lib/fontMath/test/test_mathTransform.py
@@ -1,0 +1,134 @@
+import unittest
+import math
+from random import random
+from fontMath.mathTransform import (
+    Transform, FontMathWarning, matrixToMathTransform, mathTransformToMatrix,
+    _polarDecomposeInterpolationTransformation,
+    _mathPolarDecomposeInterpolationTransformation,
+    _linearInterpolationTransformMatrix
+)
+
+
+class MathTransformToFunctionsTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_matrixToTransform(self):
+        pass
+
+    def test_TransformToMatrix(self):
+        pass
+
+
+class ShallowTransformTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+
+_testData = [
+    (
+        Transform().rotate(math.radians(0)),
+        Transform().rotate(math.radians(90))
+    ),
+
+    (
+        Transform().skew(math.radians(60), math.radians(10)),
+        Transform().rotate(math.radians(90))
+    ),
+
+    (
+        Transform().scale(.3, 1.3),
+        Transform().rotate(math.radians(90))
+    ),
+
+    (
+        Transform().scale(.3, 1.3).rotate(math.radians(-15)),
+        Transform().rotate(math.radians(90)).scale(.7, .3)
+    ),
+
+    (
+        Transform().translate(250, 250).rotate(math.radians(-15))
+        .translate(-250, -250),
+        Transform().translate(0, 400).rotate(math.radians(80))
+        .translate(-100, 0).rotate(math.radians(80)),
+    ),
+
+    (
+        Transform().skew(math.radians(50)).scale(1.5).rotate(math.radians(60)),
+        Transform().rotate(math.radians(90))
+    ),
+]
+
+
+class MathTransformTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
+        # and fires deprecation warnings if a program uses the old name.
+        if not hasattr(self, "assertRaisesRegex"):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def test_functions(self):
+        """
+        In this test various complex transformations are interpolated using
+        3 different methods:
+          - straight linear interpolation, the way glyphMath does it now.
+          - using the MathTransform interpolation method.
+          - using the ShallowTransform with an initial decompose and final
+            compose.
+        """
+        value = random()
+        testFunctions = [
+            _polarDecomposeInterpolationTransformation,
+            _mathPolarDecomposeInterpolationTransformation,
+            _linearInterpolationTransformMatrix,
+        ]
+        with self.assertRaisesRegex(
+                FontMathWarning,
+                "Minor differences occured when "
+                "comparing the interpolation functions."):
+            for i, m in enumerate(_testData):
+                m1, m2 = m
+                results = []
+                for func in testFunctions:
+                    r = func(m1, m2, value)
+                    results.append(r)
+                if not results[0] == results[1]:
+                    raise FontMathWarning(
+                        "Minor differences occured when "
+                        "comparing the interpolation functions.")
+
+    def _wrapUnWrap(self, precision=12):
+        """
+        Wrap and unwrap a matrix with random values to establish rounding error
+        """
+        t1 = []
+        for i in range(6):
+            t1.append(random())
+        m = matrixToMathTransform(t1)
+        t2 = mathTransformToMatrix(m)
+
+        if not sum([round(t1[i] - t2[i], precision)
+                    for i in range(len(t1))]) == 0:
+            raise FontMathWarning(
+                "Matrix round-tripping failed for precision value %s."
+                % (precision))
+
+    def test_wrapUnWrap(self):
+        self._wrapUnWrap()
+
+    def test_wrapUnWrapPrecision(self):
+        """
+        Wrap and unwrap should have no rounding errors at least up to
+        a precision value of 12.
+        Rounding errors seem to start occuring at a precision value of 14.
+        """
+        for p in range(5, 13):
+            for i in range(1000):
+                self._wrapUnWrap(p)
+        with self.assertRaisesRegex(
+                FontMathWarning,
+                "Matrix round-tripping failed for precision value"):
+            for p in range(14, 16):
+                for i in range(1000):
+                    self._wrapUnWrap(p)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,63 @@
+environment:
+  matrix:
+    - JOB: "2.7.11 32-bit"
+      PYTHON_HOME: "C:\\Python27"
+      TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27\\python.exe"
+
+    - JOB: "3.4.3 32-bit"
+      PYTHON_HOME: "C:\\Python34"
+      TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34\\python.exe"
+
+    - JOB: "3.5.1 32-bit"
+      PYTHON_HOME: "C:\\Python35"
+      TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35\\python.exe"
+
+    - JOB: "2.7.11 64-bit"
+      PYTHON_HOME: "C:\\Python27-x64"
+      TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27-x64\\python.exe"
+
+    - JOB: "3.4.3 64-bit"
+      PYTHON_HOME: "C:\\Python34-x64"
+      TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34-x64\\python.exe"
+      DISTUTILS_USE_SDK: "1"
+
+    - JOB: "3.5.1 64-bit"
+      PYTHON_HOME: "C:\\Python35-x64"
+      TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35-x64\\python.exe"
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
+  # Prepend Python to the PATH of this build
+  - "SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\\Scripts;%PATH%"
+
+  # check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # upgrade pip to avoid out-of-date warnings
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip --version"
+
+  # install the dependencies to run the tests
+  - "python -m pip install -r dev-requirements.txt"
+
+
+build: false
+
+test_script:
+  - "tox"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest>=2.8
+virtualenv>=15.0
+tox>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/behdad/fonttools
+git+https://github.com/unified-font-object/ufoLib

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
     url="http://code.typesupply.com",
     license="MIT",
     packages=["fontMath"],
-    package_dir={"":"Lib"}
+    package_dir={"": "Lib"},
+    test_suite="fontMath"
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,50 @@
+[tox]
+#envlist = py27, pypy, py34, py35
+envlist = py27, pypy, py34, py35
+
+[testenv]
+basepython =
+    py27: {env:TOXPYTHON:python2.7}
+    pypy: {env:TOXPYTHON:pypy}
+    py34: {env:TOXPYTHON:python3.4}
+    py35: {env:TOXPYTHON:python3.5}
+deps =
+    pytest
+    -rrequirements.txt
+install_command =
+    {envpython} -m pip install -v {opts} {packages}
+commands =
+    # check that we have the expected Python version and architecture
+    {envpython} -c "import sys; print(sys.version)"
+    {envpython} -c "import struct; print(struct.calcsize('P') * 8)"
+    {envpython} -c "import ufoLib; print(ufoLib.__file__)"
+    # run the test suite
+    py.test
+
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+basepython=python3.5
+deps =
+    {[testenv]deps}
+    pytest-cov
+    coveralls
+skip_install = true
+ignore_outcome = true
+commands=
+    # measure test coverage and upload report to coveralls
+    py.test --cov=Lib/fontMath
+    coveralls
+
+[pytest]
+minversion = 2.8
+testpaths =
+    Lib/fontMath
+python_files =
+    test_*.py
+python_classes = 
+    *Test
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a


### PR DESCRIPTION
- Move doctests to unittests in fontMath/test
- Use tox to test py27, pyp, py34, py35 (dropped py26)
- Remove Transform test that belong to fontTools (see #26)
- Add appveyor.yml

AppVeyor needs to be enabled.
Coveralls should be enabled as well.