### PR TITLE
Sortable math kerning

### DIFF
--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -25,11 +25,10 @@ from ufoLib.pointPen import AbstractPointPen
 # X image
 #
 # - is there any cruft that can be removed?
-# X why is divPt here? move all of those to the math funcions
-#   and get rid of the robofab dependency.
+# X why is divPt here? move all of those to the math functions
 # - FilterRedundantPointPen._flushContour is a mess
-# X for the pt math funcons, always send (x, y) factors instead
-#   of coercing within the funcion. the coercion can happen at
+# X for the pt math functions, always send (x, y) factors instead
+#   of coercing within the function. the coercion can happen at
 #   the beginning of the _processMathTwo method.
 #   - try list comprehensions in the point math for speed
 #

--- a/Lib/fontMath/mathKerning.py
+++ b/Lib/fontMath/mathKerning.py
@@ -257,6 +257,53 @@ class MathKerning(object):
         font.kerning.update(self._kerning)
         font.groups.update(self.groups())
 
+    # -------
+    # Sorting
+    # -------
+    def _isLessish(self, first, second):
+        if len(first) < len(second):
+            return True
+        elif len(first) > len(second):
+            return False
+
+        first_keys = sorted(first)
+        second_keys = sorted(second)
+        for i, key in enumerate(first_keys):
+            if first_keys[i] < second_keys[i]:
+                return True
+            elif first_keys[i] > second_keys[i]:
+                return False
+            elif first[key] < second[key]:
+                return True
+        return None
+
+    def __lt__(self, other):
+        if other is None:
+            return False
+
+        lessish = self._isLessish(self._kerning, other._kerning)
+        if lessish is not None:
+            return lessish
+
+        lessish = self._isLessish(self._side1Groups, other._side1Groups)
+        if lessish is not None:
+            return lessish
+
+        lessish = self._isLessish(self._side2Groups, other._side2Groups)
+        if lessish is not None:
+            return lessish
+
+        return False
+
+    def __eq__(self, other):
+        if self._kerning != other._kerning:
+            return False
+        if self._side1Groups != other._side1Groups:
+            return False
+        if self._side2Groups != other._side2Groups:
+            return False
+        return True
+
 
 if __name__ == "__main__":
     import sys

--- a/Lib/fontMath/test/test_mathKerning.py
+++ b/Lib/fontMath/test/test_mathKerning.py
@@ -324,6 +324,119 @@ class MathKerningTest(unittest.TestCase):
              (('C2', 'public.kern2.C'), 0),
              (('public.kern1.C', 'public.kern2.C'), 2)])
 
+    def test_compare_same_kerning_only(self):
+        kerning1 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+        }
+        kerning2 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+        }
+        mathKerning1 = MathKerning(kerning1, {})
+        mathKerning2 = MathKerning(kerning2, {})
+        self.assertFalse(mathKerning1 < mathKerning2)
+        self.assertFalse(mathKerning1 > mathKerning2)
+        self.assertEqual(mathKerning1, mathKerning2)
+
+    def test_compare_same_kerning_same_groups(self):
+        kerning1 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        kerning2 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        mathKerning1 = MathKerning(kerning1, groups)
+        mathKerning2 = MathKerning(kerning2, groups)
+        self.assertFalse(mathKerning1 < mathKerning2)
+        self.assertFalse(mathKerning1 > mathKerning2)
+        self.assertEqual(mathKerning1, mathKerning2)
+
+    def test_compare_diff_kerning_diff_groups(self):
+        kerning1 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        kerning2 = {
+            ("A", "A"): 0,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups1 = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2", "C3"],
+        }
+        groups2 = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        mathKerning1 = MathKerning(kerning1, groups1)
+        mathKerning2 = MathKerning(kerning2, groups2)
+        self.assertFalse(mathKerning1 < mathKerning2)
+        self.assertTrue(mathKerning1 > mathKerning2)
+        self.assertNotEqual(mathKerning1, mathKerning2)
+
+    def test_compare_diff_kerning_same_groups(self):
+        kerning1 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        kerning2 = {
+            ("A", "A"): 0,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        mathKerning1 = MathKerning(kerning1, groups)
+        mathKerning2 = MathKerning(kerning2, groups)
+        self.assertFalse(mathKerning1 < mathKerning2)
+        self.assertTrue(mathKerning1 > mathKerning2)
+        self.assertNotEqual(mathKerning1, mathKerning2)
+
+    def test_compare_same_kerning_diff_groups(self):
+        kerning1 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        kerning2 = {
+            ("A", "A"): 0,
+            ("B", "B"): 4,
+            ("C2", "public.kern2.C"): 0,
+            ("public.kern1.C", "public.kern2.C"): 4,
+        }
+        groups1 = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2"],
+        }
+        groups2 = {
+            "public.kern1.C": ["C1", "C2"],
+            "public.kern2.C": ["C1", "C2", "C3"],
+        }
+        mathKerning1 = MathKerning(kerning1, groups1)
+        mathKerning2 = MathKerning(kerning2, groups2)
+        self.assertTrue(mathKerning1 < mathKerning2)
+        self.assertFalse(mathKerning1 > mathKerning2)
+        self.assertNotEqual(mathKerning1, mathKerning2)
+
     def test_div_tuple_factor(self):
         kerning = {
             ("A", "A"): 0,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-#envlist = py27, pypy, py34, py35
 envlist = py27, pypy, py34, py35
 
 [testenv]
@@ -16,8 +15,6 @@ install_command =
 commands =
     # check that we have the expected Python version and architecture
     {envpython} -c "import sys; print(sys.version)"
-    {envpython} -c "import struct; print(struct.calcsize('P') * 8)"
-    {envpython} -c "import ufoLib; print(ufoLib.__file__)"
     # run the test suite
     py.test
 
@@ -41,7 +38,7 @@ testpaths =
     Lib/fontMath
 python_files =
     test_*.py
-python_classes = 
+python_classes =
     *Test
 addopts =
     # run py.test in verbose mode


### PR DESCRIPTION
In Python3 MathKerning isn’t sortable unless we make it so.