### PR TITLE
Keep guideline angles between 0 and 360.

### DIFF
--- a/Lib/fontMath/mathGuideline.py
+++ b/Lib/fontMath/mathGuideline.py
@@ -83,7 +83,7 @@ def _processMathOneGuidelines(guidelinePairs, ptFunc, func):
         guideline["x"], guideline["y"] = ptFunc(pt1, pt2)
         angle1 = guideline1["angle"]
         angle2 = guideline2["angle"]
-        guideline["angle"] = func(angle1, angle2)
+        guideline["angle"] = func(angle1, angle2) % 360
         result.append(guideline)
     return result
 
@@ -94,7 +94,7 @@ def _processMathTwoGuidelines(guidelines, factor, func):
         guideline["x"] = func(guideline["x"], factor[0])
         guideline["y"] = func(guideline["y"], factor[1])
         angle = guideline["angle"]
-        guideline["angle"] = factorAngle(angle, factor, func)
+        guideline["angle"] = factorAngle(angle, factor, func) % 360
         result.append(guideline)
     return result
 

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -369,6 +369,32 @@ class MathGlyphTest(unittest.TestCase):
         ]
         self.assertEqual(glyph2.guidelines, expected)
 
+    def test_guidelines_valid_angle(self):
+        glyph1 = self._setupTestGlyph()
+        glyph1.guidelines = [
+            dict(name="foo", identifier="1", x=0, y=0, angle=1)
+        ]
+        glyph2 = self._setupTestGlyph()
+        glyph2.guidelines = [
+            dict(name="foo", identifier="1", x=0, y=0, angle=359)
+        ]
+
+        expected_add = [dict(name="foo", identifier="1", x=0, y=0, angle=0)]
+        glyph3 = glyph1 + glyph2
+        self.assertEqual(glyph3.guidelines, expected_add)
+
+        expected_sub = [dict(name="foo", identifier="1", x=0, y=0, angle=2)]
+        glyph4 = glyph1 - glyph2
+        self.assertEqual(glyph4.guidelines, expected_sub)
+
+        expected_mul = [dict(name="foo", identifier="1", x=0, y=0, angle=359)]
+        glyph5 = glyph2 * 5
+        self.assertEqual(glyph5.guidelines, expected_mul)
+
+        expected_div = [dict(name="foo", identifier="1", x=0, y=0, angle=359)]
+        glyph6 = glyph2 / 5
+        self.assertEqual(glyph6.guidelines, expected_div)
+
     def test_anchors_add(self):
         glyph1 = self._setupTestGlyph()
         glyph1.anchors = [


### PR DESCRIPTION
UFO guideline angles must be between 0 and 360.

See https://github.com/googlei18n/fontmake/issues/132.
