### PR TITLE
use Python 3 instead of Python 2 round()

### DIFF
--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import math
+from fontTools.misc.py23 import round3 as _roundNumber
 
 __all__ = [
     "add",
@@ -12,7 +13,6 @@ __all__ = [
     "divPt",
     "factorAngle",
     "_roundNumber",
-
 ]
 
 def add(v1, v2):
@@ -52,17 +52,6 @@ def factorAngle(angle, f, func):
         )
     )
 
-def _roundNumber(n, digits=None):
-    # Python3 rounds halves to nearest even integer but Python2 rounds
-    # halves up in positives and down in negatives
-    if round(0.5) != 1 and n % 1 == .5 and not int(n) % 2:
-        if digits is None:
-            return int((round(n) + (abs(n) / n) * 1))
-        return int((round(n) + 1, digits))
-    else:
-        if digits is None:
-            return int(round(n))
-        return round(n, digits)
 
 if __name__ == "__main__":
     import sys

--- a/Lib/fontMath/mathInfo.py
+++ b/Lib/fontMath/mathInfo.py
@@ -179,7 +179,7 @@ class MathInfo(object):
                 v = getattr(copiedInfo, attr)
                 if v is not None:
                     if factorIndex == 3:
-                        v = int(round(v))
+                        v = _roundNumber(v)
                     else:
                         if isinstance(v, (list, tuple)):
                             v = [_roundNumber(a, digits) for a in v]
@@ -203,6 +203,7 @@ class MathInfo(object):
     def extractInfo(self, otherInfoObject):
         """
         >>> from fontMath.test.test_mathInfo import _TestInfoObject, _testData
+        >>> from fontMath.mathFunctions import _roundNumber
         >>> info1 = MathInfo(_TestInfoObject())
         >>> info2 = info1 * 2.5
         >>> info3 = _TestInfoObject()
@@ -214,9 +215,9 @@ class MathInfo(object):
         ...         continue
         ...     written[attr] = getattr(info2, attr)
         ...     if isinstance(value, list):
-        ...         expectedValue = [int(round(v * 2.5)) for v in value]
+        ...         expectedValue = [_roundNumber(v * 2.5) for v in value]
         ...     elif isinstance(value, int):
-        ...         expectedValue = int(round(value * 2.5))
+        ...         expectedValue = _roundNumber(value * 2.5)
         ...     else:
         ...         expectedValue = value * 2.5
         ...     expected[attr] = expectedValue
@@ -284,7 +285,7 @@ def _numberFormatter(value):
     return value
 
 def _integerFormatter(value):
-    return int(round(value))
+    return _roundNumber(value)
 
 def _floatFormatter(value):
     return float(value)
@@ -347,7 +348,7 @@ def _openTypeOS2WeightClassFormatter(value):
     >>> _openTypeOS2WeightClassFormatter(120)
     120
     """
-    value = int(round(value))
+    value = _roundNumber(value)
     if value < 0:
         value = 0
     return value

--- a/Lib/fontMath/mathInfo.py
+++ b/Lib/fontMath/mathInfo.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import
 from fontMath.mathFunctions import (
     add, addPt, div, factorAngle, mul, _roundNumber, sub, subPt)
+from fontTools.misc.py23 import round2
 from fontMath.mathGuideline import (
     _expandGuideline, _pairGuidelines, _processMathOneGuidelines,
     _processMathTwoGuidelines, _roundGuidelines)
@@ -149,14 +150,9 @@ class MathInfo(object):
         name = None
         if hasattr(copiedInfo, "openTypeOS2WeightClass") and copiedInfo.openTypeOS2WeightClass is not None:
             v = copiedInfo.openTypeOS2WeightClass
-            v = v * .01
-            # Python3 rounds halves to nearest even integer
-            # but Python2 rounds halves up.
-            if round(0.5) != 1 and v % 1 == .5 and not int(v) % 2:
-                v = int((round(v) + 1) * 100)
-            else:
-                v = int(round(v) * 100)
-            v = int(round(v * .01) * 100)
+            # here we use Python 2 rounding (i.e. away from 0) instead of Python 3:
+            # e.g. 150 -> 200 and 250 -> 300, instead of 150 -> 200 and 250 -> 200
+            v = int(round2(v, -2))
             if v < 100:
                 v = 100
             elif v > 900:
@@ -328,7 +324,7 @@ def _openTypeOS2WidthClassFormatter(value):
     >>> _openTypeOS2WidthClassFormatter(12)
     9
     """
-    value = int(round(value))
+    value = int(round2(value))
     if value > 9:
         value = 9
     elif value < 1:

--- a/Lib/fontMath/mathKerning.py
+++ b/Lib/fontMath/mathKerning.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import
 from copy import deepcopy
 from fontMath.mathFunctions import add, sub, mul, div
+from fontTools.misc.py23 import round2
 
 """
 An object that serves kerning data from a
@@ -232,7 +233,7 @@ class MathKerning(object):
     def round(self, multiple=1):
         multiple = float(multiple)
         for k, v in self._kerning.items():
-            self._kerning[k] = int(round(int(round(v / multiple)) * multiple))
+            self._kerning[k] = int(round2(int(round2(v / multiple)) * multiple))
 
     # -------
     # Cleanup

--- a/Lib/fontMath/test/test_mathFunctions.py
+++ b/Lib/fontMath/test/test_mathFunctions.py
@@ -45,7 +45,7 @@ class MathFunctionsTest(unittest.TestCase):
 
     def test_factorAngle(self):
         f = factorAngle(5, (2, 1.5), mul)
-        self.assertEqual(round(f, 2), 3.75)
+        self.assertEqual(_roundNumber(f, 2), 3.75)
 
     def test_roundNumber(self):
         # round to integer:
@@ -53,9 +53,11 @@ class MathFunctionsTest(unittest.TestCase):
         self.assertEqual(_roundNumber(0.1), 0)
         self.assertEqual(_roundNumber(0.99), 1)
         self.assertEqual(_roundNumber(0.499), 0)
-        self.assertEqual(_roundNumber(0.5), 1)
+        self.assertEqual(_roundNumber(0.5), 0)
         self.assertEqual(_roundNumber(-0.499), 0)
-        self.assertEqual(_roundNumber(-0.5), -1)
+        self.assertEqual(_roundNumber(-0.5), 0)
+        self.assertEqual(_roundNumber(1.5), 2)
+        self.assertEqual(_roundNumber(-1.5), -2)
 
     def test_roundNumber_to_float(self):
         # round to float with specified decimals:

--- a/Lib/fontMath/test/test_mathGuideline.py
+++ b/Lib/fontMath/test/test_mathGuideline.py
@@ -1,5 +1,5 @@
 import unittest
-from fontMath.mathFunctions import add, addPt, mul
+from fontMath.mathFunctions import add, addPt, mul, _roundNumber
 from fontMath.mathGuideline import (
     _expandGuideline, _compressGuideline, _pairGuidelines,
     _processMathOneGuidelines, _processMathTwoGuidelines, _roundGuidelines
@@ -215,7 +215,7 @@ class MathGuidelineTest(unittest.TestCase):
             dict(x=4, y=4.5, angle=3.75, name="test", identifier="1", color="0,0,0,0")
         ]
         result = _processMathTwoGuidelines(guidelines, (2, 1.5), mul)
-        result[0]["angle"] = round(result[0]["angle"], 2)
+        result[0]["angle"] = _roundNumber(result[0]["angle"], 2)
         self.assertEqual(result, expected)
 
     def test_roundGuidelines(self):

--- a/Lib/fontMath/test/test_mathKerning.py
+++ b/Lib/fontMath/test/test_mathKerning.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import unittest
+from fontMath.mathFunctions import _roundNumber
 from fontMath.mathKerning import MathKerning
 
 
@@ -14,7 +15,7 @@ class TestKerning(object):
     def asDict(self, returnIntegers=True):
         if not returnIntegers:
             return self._kerning
-        kerning = {k: int(round(v)) for (k, v) in self._kerning.items()}
+        kerning = {k: _roundNumber(v) for (k, v) in self._kerning.items()}
         return kerning
 
     def update(self, kerningDict):

--- a/Lib/fontMath/test/test_mathTransform.py
+++ b/Lib/fontMath/test/test_mathTransform.py
@@ -1,6 +1,7 @@
 import unittest
 import math
 from random import random
+from fontMath.mathFunctions import _roundNumber
 from fontMath.mathTransform import (
     Transform, FontMathWarning, matrixToMathTransform, mathTransformToMatrix,
     _polarDecomposeInterpolationTransformation,
@@ -108,7 +109,7 @@ class MathTransformTest(unittest.TestCase):
         m = matrixToMathTransform(t1)
         t2 = mathTransformToMatrix(m)
 
-        if not sum([round(t1[i] - t2[i], precision)
+        if not sum([_roundNumber(t1[i] - t2[i], precision)
                     for i in range(len(t1))]) == 0:
             raise FontMathWarning(
                 "Matrix round-tripping failed for precision value %s."


### PR DESCRIPTION
In fonttools we have an implementation of the Python 3 built-in `round()` function:

https://github.com/fonttools/fonttools/blob/master/Lib/fontTools/misc/py23.py#L298-L340

fontMath currently uses sometimes an implementation by @moyogo of Python 2 rounding (`mathFunctions._roundNumber`), other times the built-in `round` (which differs across Python major versions).

I think fontMath should do the same as fonttools and use Python 3 rounding as the default `round` function on both Python 2 and 3.

Except where Python 2 rounding makes more sense, e.g. in the PostScript Weight which rounded in the hundreds.

Please let me know what you think.