### PR TITLE
mathFunctions: add workaround for inconsistent round() behavior in Python < 3.6

### DIFF
--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -1,6 +1,6 @@
 from __future__ import division
 import math
-from fontTools.misc.py23 import round3 as _roundNumber
+from fontTools.misc.py23 import round3 as _round3
 
 __all__ = [
     "add",
@@ -51,6 +51,12 @@ def factorAngle(angle, f, func):
             func(y, f2), func(x, f1)
         )
     )
+
+def _roundNumber(number, ndigits=None):
+    # workaround inconsistent round() behavior in Python < 3.6:
+    # floats accept a second argument ndigits=None, whereas integers
+    # raise TypeError. See https://bugs.python.org/issue27936
+    return _round3(number) if ndigits is None else _round3(number, ndigits)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On Python 3, FontTools' `round3` function is simply an alias of the built-in
`round()` function.

The latter has inconsistent behaviour when the first argument is a float or an
int, and when the second argument (ndigits) is passed with value None.

floats accept a second argument ndigits=None just fine:

```python
>>> round(2.0, None)
2
```

Whereas integers raise a TypeError if the second argument is None:

```python
>>> round(2, None)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

You can see the Travis tests failing here:
https://travis-ci.org/typesupply/fontMath/jobs/180663571

Note that this bug will be fixed in the upcoming Python 3.6
For more info, see: https://bugs.python.org/issue27936
