### PR TITLE
[mathGlyph] replace __cmp__ with __eq__ for py2/3 compatibility

### DIFF
--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -97,31 +97,17 @@ class MathGlyph(object):
             self.height = glyph.height
             self.note = glyph.note
 
-    def __cmp__(self, other):
-        flag = False
-        if self.name != other.name:
-            flag = True
-        if self.unicodes != other.unicodes:
-            flag = True
-        if self.width != other.width:
-            flag = True
-        if self.height != other.height:
-            flag = True
-        if self.note != other.note:
-            flag = True
-        if self.lib != other.lib:
-            flag = True
-        if self.contours != other.contours:
-            flag = True
-        if self.components != other.components:
-            flag = True
-        if self.anchors != other.anchors:
-            flag = True
-        if self.guidelines != other.guidelines:
-            flag = True
-        if self.image != other.image:
-            flag = True
-        return flag
+    def __eq__(self, other):
+        try:
+            return all(getattr(self, attr) == getattr(other, attr)
+                       for attr in ("name", "unicodes", "width", "height",
+                                    "note", "lib", "contours", "components",
+                                    "anchors", "guidelines", "image"))
+        except AttributeError:
+            return NotImplemented
+
+    def __ne__(self, other):
+        return not self == other
 
     # ----
     # Copy

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -31,6 +31,47 @@ class MathGlyphTest(unittest.TestCase):
         glyph.height = 0
         return glyph
 
+    def test__eq__(self):
+        glyph1 = self._setupTestGlyph()
+        glyph2 = self._setupTestGlyph()
+        self.assertEqual(glyph1, glyph2)
+
+        glyph2.width = 1
+        self.assertFalse(glyph1 == glyph2)
+
+        nonglyph = object()
+        self.assertFalse(glyph1 == nonglyph)
+
+        glyph1 = MathGlyph(None)
+        glyph1.name = 'space'
+        glyph1.width = 100
+
+        class MyGlyph(object):
+            pass
+        other = MyGlyph()
+        other.name = 'space'
+        other.width = 100
+        other.height = None
+        other.contours = []
+        other.components = []
+        other.anchors = []
+        other.guidelines = []
+        other.image = {'fileName': None,
+                       'transformation': (1, 0, 0, 1, 0, 0),
+                       'color': None}
+        other.lib = {}
+        other.unicodes = None
+        other.note = None
+        self.assertEqual(glyph1, other)
+
+    def test__ne__(self):
+        glyph1 = self._setupTestGlyph()
+        glyph2 = MathGlyph(None)
+        glyph2.width = 1
+        glyph2.name = 'a'
+        self.assertNotEqual(glyph1, glyph2)
+        self.assertNotEqual(glyph1, 'foo')
+
     def test_width_add(self):
         glyph1 = self._setupTestGlyph()
         glyph1.width = 1


### PR DESCRIPTION
`__cmp__` does not work anymore on python 3.
I replaced it with `__eq__` and `__ne__` to accomplish the same job as the previous one.
Comparing two mathGlyphs for equality now works on both Python2 and 3.
I didn't implement the full list of rich comparison operators because the previous `__cmp__` method which I replaced was only making sense for `==` and `!=`.

Fixes #42 