### PR TITLE
Try to keep the glyph order in kerning groups

### DIFF
--- a/Lib/fontMath/mathKerning.py
+++ b/Lib/fontMath/mathKerning.py
@@ -177,15 +177,15 @@ class MathKerning(object):
             kerning[k] = v
         g1 = self.groups()
         g2 = other.groups()
-        if g1 == g2:
-            groups = g1
+        if g1 == g2 or not g1 or not g2:
+            groups = g1 or g2
         else:
             comboGroups = set(g1.keys()) | set(g2.keys())
             groups = dict.fromkeys(comboGroups, None)
             for groupName in comboGroups:
                 s1 = set(g1.get(groupName, []))
                 s2 = set(g2.get(groupName, []))
-                groups[groupName] = list(s1 | s2)
+                groups[groupName] = sorted(list(s1 | s2))
         ks = MathKerning(kerning, groups)
         return ks
 


### PR DESCRIPTION
When one set of the groups is empty just use the other as is, keeping
the original glyph order. Otherwise sort the glyph list to at least keep
the order deterministic.

I reached here trying to find out why rebuilding the same fonts with
font make will always produce a different GPOS table. Turned out this is
caused by different glyph order in the kerning groups, which was caused
by MutatorMath writing instance UFO files with different glyph order
each time.