### PR TITLE
Preserve the anchors' ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov/
 
 # OS X Finder
 .DS_Store
+.pytest_cache

--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import
 from copy import deepcopy
+from collections import OrderedDict
 from fontMath.mathFunctions import (
     add, addPt, div, divPt, mul, mulPt, _roundNumber, sub, subPt)
 from fontMath.mathGuideline import (
@@ -12,8 +13,6 @@ from ufoLib.pointPen import AbstractPointPen
 # ------------------
 #
 # to do:
-# X anchors
-#   - try to preserve ordering?
 # X components
 #   X identifiers
 # X contours
@@ -523,7 +522,7 @@ def _processMathTwoContours(contours, factor, func):
 # anchors
 
 def _anchorTree(anchors):
-    tree = {}
+    tree = OrderedDict()
     for anchor in anchors:
         x = anchor["x"]
         y = anchor["y"]

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -703,21 +703,25 @@ class PrivateFuncsTest(unittest.TestCase):
             dict(name="test", x=1, y=2, color=None),
             dict(name="test", x=3, y=4, color=None),
             dict(name="test", x=2, y=3, color=None),
-            dict(name="test 2", x=1, y=2, color=None),
+            dict(name="c", x=1, y=2, color=None),
+            dict(name="a", x=0, y=0, color=None),
         ]
         self.assertEqual(
-            _anchorTree(anchors),
-            {
-                "test": [
+            list(_anchorTree(anchors).items()),
+            [
+                ("test", [
                     ("1", 1, 2, None),
                     (None, 1, 2, None),
                     (None, 3, 4, None),
-                    (None, 2, 3, None),
-                ],
-                "test 2": [
+                    (None, 2, 3, None)
+                ]),
+                ("c", [
                     (None, 1, 2, None)
-                ]
-            }
+                ]),
+                ("a", [
+                    (None, 0, 0, None)
+                ])
+            ]
         )
 
     def test_pairAnchors_matching_identifiers(self):


### PR DESCRIPTION
The ordering of the anchors is not preserved, which leads to differences between py27 and py36 in .glif files.

This issue is a blocker for our PR at https://github.com/adobe-type-tools/afdko/pull/593

We'd appreciate if these changes could be merged soon and a new fontMath version issued this week. Thank you.